### PR TITLE
Enable to see prefs info for migration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,11 @@
 language: android
 
-jdk:
-  - oraclejdk7
-  - oraclejdk8
-
 android:
   components:
-    - build-tools-22.0.1
+    - build-tools-23.0.1
     - extra-android-m2repository
     - extra-google-m2repository
-    - android-22
+    - android-23
 
 script:
   - ./gradlew connectedCheck

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,16 @@
 language: android
+
 jdk:
-    - oraclejdk8
+  - oraclejdk7
+  - oraclejdk8
+
 android:
   components:
-    - export TERM=dumb
-    - echo yes | android update sdk --no-ui --all --filter tools,platform-tools,build-tools-22.1.2,android-21,extra-android-m2repository,extra-google-m2repository
-    - emulator -avd test -no-skin -no-audio -no-window &
-    - android-wait-for-emulator
-    - adb shell input keyevent 82 &
+    - build-tools-22.0.1
+    - extra-android-m2repository
+    - extra-google-m2repository
+    - android-22
+
 script:
   - ./gradlew connectedCheck
   - ./gradlew connectedAndroidTest

--- a/README.md
+++ b/README.md
@@ -105,16 +105,17 @@ public abstract class ExamplePrefsSchema extends PrefSchema {
 In addition, SharedPreferencesInfo may help you to migrate existing app. You can get existing SharedPreferences through `SharedPreferencesInfo.getAllPrefsAsTable`.
 
 ```java
-List<SharedPreferencesTable> tables = SharedPreferencesInfo.getAllPrefsAsTable(this);
+List<SharedPreferencesTable> tables = SharedPreferencesInfo.getAll(this);
         for (SharedPreferencesTable table : tables) {
             Log.d("DEBUG", table.toString());
         }
 ```
 
-You can see what data is saved in your app.
+You can see what kind of data is saved in your app like below.
 
 ```
    name: com.example.android.kvs_preferences
+   path: /data/data/com.example.android.kvs/shared_prefs/com.example.android.kvs_preferences.xml
  ╔═══════════╤═════════╗
  ║ Key       │ Type    ║
  ╠═══════════╪═════════╣

--- a/README.md
+++ b/README.md
@@ -116,13 +116,13 @@ You can see what kind of data is saved in your app like below.
 ```
    name: com.example.android.kvs_preferences
    path: /data/data/com.example.android.kvs/shared_prefs/com.example.android.kvs_preferences.xml
- ╔═══════════╤═════════╗
- ║ Key       │ Type    ║
- ╠═══════════╪═════════╣
- ║ user_name │ String  ║
- ╟───────────┼─────────╢
- ║ user_id   │ Long    ║
- ╚═══════════╧═════════╝
+ ╔═══════════╤══════════════╤════════╗
+ ║ Key       │ Value        │ Type   ║
+ ╠═══════════╪══════════════╪════════╣
+ ║ user_name │ rejasupotaro │ String ║
+ ╟───────────┼──────────────┼────────╢
+ ║ user_id   │ 1            │ String ║
+ ╚═══════════╧══════════════╧════════╝
  ```
 
 For developers

--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@ KVS Schema is a code generation library to manage key-value data for Android.
 I use SharedPreferences to save values. However, sometimes I forget key names and types.
 This library helps you to manage key-value data. You can find the structure of pref file at a glance.
 
-Even if you have already used SharedPreferences directly, migration is easy because KVS Schema simply maps the structure of SharedPreferences.
-
 How to use
 ----------
 
@@ -74,6 +72,57 @@ Add dependencies your build.gradle
 apt 'com.rejasupotaro:kvs-schema-compiler:1.2.0'
 compile 'com.rejasupotaro:kvs-schema:1.2.0'
 ```
+
+Migration
+----------
+
+Even if you have already used SharedPreferences directly, migration is easy. KVS Schema simply maps the structure of SharedPreferences.
+
+For example, if you are using default SharedPreferences like below,
+
+```java
+prefs = PreferenceManager.getDefaultSharedPreferences(this);
+Editor editor = prefs.edit();
+editor.putString("user_id", "1");
+editor.putString("user_name", "rejasupotaro");
+editor.apply();
+```
+
+your data is saved in `path/to/app/shared_prefs/package_name_preferences.xml`. The schema becomes below.
+
+```java
+@Table("package_name_preferences")
+public abstract class ExamplePrefsSchema extends PrefSchema {
+    public static ExamplePrefs prefs;
+
+    @Key("user_id")
+    int userId;
+    @Key("user_name")
+    String userName;
+}
+```
+
+In addition, SharedPreferencesInfo may help you to migrate existing app. You can get existing SharedPreferences through `SharedPreferencesInfo.getAllPrefsAsTable`.
+
+```java
+List<SharedPreferencesTable> tables = SharedPreferencesInfo.getAllPrefsAsTable(this);
+        for (SharedPreferencesTable table : tables) {
+            Log.d("DEBUG", table.toString());
+        }
+```
+
+You can see what data is saved in your app.
+
+```
+   name: com.example.android.kvs_preferences
+ ╔═══════════╤═════════╗
+ ║ Key       │ Type    ║
+ ╠═══════════╪═════════╣
+ ║ user_name │ String  ║
+ ╟───────────┼─────────╢
+ ║ user_id   │ Long    ║
+ ╚═══════════╧═════════╝
+ ```
 
 For developers
 ----------

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -29,6 +29,7 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
+    compile 'com.jakewharton.fliptables:fliptables:1.0.2'
 }
 
 publish {

--- a/library/src/main/java/com/rejasupotaro/android/kvs/SharedPreferencesInfo.java
+++ b/library/src/main/java/com/rejasupotaro/android/kvs/SharedPreferencesInfo.java
@@ -4,46 +4,45 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
-import android.util.Log;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 public class SharedPreferencesInfo {
-
-    public static void dump(Context context) {
-        List<SharedPreferences> sharedPreferencesList = getAllSharedPreferences(context);
-
-        for (SharedPreferences sharedPreferences : sharedPreferencesList) {
-            for (Map.Entry<String, ?> entry : sharedPreferences.getAll().entrySet()) {
-                String keyName = entry.getKey();
-                String valueType = entry.getValue().getClass().getSimpleName();
-                Log.d("DEBUG", String.format("%s %s", keyName, valueType));
-            }
-        }
-    }
-
-    public static List<SharedPreferences> getAllSharedPreferences(Context context) {
-        File sharedPrefsDir = getSharedPrefsDir(context);
-        File[] sharedPrefsFiles = sharedPrefsDir.listFiles();
-        if (sharedPrefsFiles == null || sharedPrefsFiles.length == 0) {
+    public static List<SharedPreferencesTable> getAllPrefsAsTable(Context context) {
+        HashMap<String, SharedPreferences> sharedPreferencesMap = getAllPrefs(context);
+        if (sharedPreferencesMap.isEmpty()) {
             return new ArrayList<>();
         }
 
-        List<SharedPreferences> sharedPreferencesList = new ArrayList<>();
-        for (File file : sharedPrefsFiles) {
-            String filenameWithoutExtension = file.getName().split("\\.(?=[^\\.]+$)")[0];
-            Log.e("DEBUG", filenameWithoutExtension);
-
-            SharedPreferences prefs = context.getSharedPreferences(filenameWithoutExtension, Context.MODE_PRIVATE);
-            sharedPreferencesList.add(prefs);
+        List<SharedPreferencesTable> sharedPreferencesTables = new ArrayList<>();
+        for (Map.Entry<String, SharedPreferences> entry : sharedPreferencesMap.entrySet()) {
+            SharedPreferencesTable sharedPreferencesTable = new SharedPreferencesTable(entry.getKey(), entry.getValue());
+            sharedPreferencesTables.add(sharedPreferencesTable);
         }
-        return sharedPreferencesList;
+        return sharedPreferencesTables;
     }
 
-    public static File getSharedPrefsDir(Context context) {
+    public static HashMap<String, SharedPreferences> getAllPrefs(Context context) {
+        File sharedPrefsDir = getPrefsDir(context);
+        File[] sharedPrefsFiles = sharedPrefsDir.listFiles();
+        if (sharedPrefsFiles == null || sharedPrefsFiles.length == 0) {
+            return new HashMap<>();
+        }
+
+        HashMap<String, SharedPreferences> sharedPreferencesMap = new HashMap<>();
+        for (File file : sharedPrefsFiles) {
+            String filenameWithoutExtension = file.getName().split("\\.(?=[^\\.]+$)")[0];
+            SharedPreferences prefs = context.getSharedPreferences(filenameWithoutExtension, Context.MODE_PRIVATE);
+            sharedPreferencesMap.put(filenameWithoutExtension, prefs);
+        }
+        return sharedPreferencesMap;
+    }
+
+    public static File getPrefsDir(Context context) {
         return new File(getApplicationDataDir(context), "/shared_prefs");
     }
 

--- a/library/src/main/java/com/rejasupotaro/android/kvs/SharedPreferencesInfo.java
+++ b/library/src/main/java/com/rejasupotaro/android/kvs/SharedPreferencesInfo.java
@@ -7,42 +7,30 @@ import android.content.pm.PackageManager;
 
 import java.io.File;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 public class SharedPreferencesInfo {
-    public static List<SharedPreferencesTable> getAllPrefsAsTable(Context context) {
-        HashMap<String, SharedPreferences> sharedPreferencesMap = getAllPrefs(context);
-        if (sharedPreferencesMap.isEmpty()) {
+    public static List<SharedPreferencesTable> getAll(Context context) {
+        File sharedPrefsDir = getSharedPrefsDir(context);
+        File[] sharedPrefsFiles = sharedPrefsDir.listFiles();
+        if (sharedPrefsFiles == null || sharedPrefsFiles.length == 0) {
             return new ArrayList<>();
         }
 
         List<SharedPreferencesTable> sharedPreferencesTables = new ArrayList<>();
-        for (Map.Entry<String, SharedPreferences> entry : sharedPreferencesMap.entrySet()) {
-            SharedPreferencesTable sharedPreferencesTable = new SharedPreferencesTable(entry.getKey(), entry.getValue());
+        for (File file : sharedPrefsFiles) {
+            String filenameWithoutExtension = file.getName().split("\\.(?=[^\\.]+$)")[0]; // shared preferences name
+            SharedPreferences sharedPreferences = context.getSharedPreferences(filenameWithoutExtension, Context.MODE_PRIVATE);
+            SharedPreferencesTable sharedPreferencesTable = new SharedPreferencesTable(
+                    sharedPreferences,
+                    filenameWithoutExtension,
+                    file.getAbsolutePath());
             sharedPreferencesTables.add(sharedPreferencesTable);
         }
         return sharedPreferencesTables;
     }
 
-    public static HashMap<String, SharedPreferences> getAllPrefs(Context context) {
-        File sharedPrefsDir = getPrefsDir(context);
-        File[] sharedPrefsFiles = sharedPrefsDir.listFiles();
-        if (sharedPrefsFiles == null || sharedPrefsFiles.length == 0) {
-            return new HashMap<>();
-        }
-
-        HashMap<String, SharedPreferences> sharedPreferencesMap = new HashMap<>();
-        for (File file : sharedPrefsFiles) {
-            String filenameWithoutExtension = file.getName().split("\\.(?=[^\\.]+$)")[0];
-            SharedPreferences prefs = context.getSharedPreferences(filenameWithoutExtension, Context.MODE_PRIVATE);
-            sharedPreferencesMap.put(filenameWithoutExtension, prefs);
-        }
-        return sharedPreferencesMap;
-    }
-
-    public static File getPrefsDir(Context context) {
+    public static File getSharedPrefsDir(Context context) {
         return new File(getApplicationDataDir(context), "/shared_prefs");
     }
 

--- a/library/src/main/java/com/rejasupotaro/android/kvs/SharedPreferencesInfo.java
+++ b/library/src/main/java/com/rejasupotaro/android/kvs/SharedPreferencesInfo.java
@@ -1,0 +1,60 @@
+package com.rejasupotaro.android.kvs;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.content.pm.PackageInfo;
+import android.content.pm.PackageManager;
+import android.util.Log;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class SharedPreferencesInfo {
+
+    public static void dump(Context context) {
+        List<SharedPreferences> sharedPreferencesList = getAllSharedPreferences(context);
+
+        for (SharedPreferences sharedPreferences : sharedPreferencesList) {
+            for (Map.Entry<String, ?> entry : sharedPreferences.getAll().entrySet()) {
+                String keyName = entry.getKey();
+                String valueType = entry.getValue().getClass().getSimpleName();
+                Log.d("DEBUG", String.format("%s %s", keyName, valueType));
+            }
+        }
+    }
+
+    public static List<SharedPreferences> getAllSharedPreferences(Context context) {
+        File sharedPrefsDir = getSharedPrefsDir(context);
+        File[] sharedPrefsFiles = sharedPrefsDir.listFiles();
+        if (sharedPrefsFiles == null || sharedPrefsFiles.length == 0) {
+            return new ArrayList<>();
+        }
+
+        List<SharedPreferences> sharedPreferencesList = new ArrayList<>();
+        for (File file : sharedPrefsFiles) {
+            String filenameWithoutExtension = file.getName().split("\\.(?=[^\\.]+$)")[0];
+            Log.e("DEBUG", filenameWithoutExtension);
+
+            SharedPreferences prefs = context.getSharedPreferences(filenameWithoutExtension, Context.MODE_PRIVATE);
+            sharedPreferencesList.add(prefs);
+        }
+        return sharedPreferencesList;
+    }
+
+    public static File getSharedPrefsDir(Context context) {
+        return new File(getApplicationDataDir(context), "/shared_prefs");
+    }
+
+    public static File getApplicationDataDir(Context context) {
+        try {
+            PackageManager packageManager = context.getPackageManager();
+            String packageName = context.getPackageName();
+            PackageInfo packageInfo = packageManager.getPackageInfo(packageName, 0);
+            return new File(packageInfo.applicationInfo.dataDir);
+        } catch (PackageManager.NameNotFoundException e) {
+            throw new IllegalStateException("Package name not found: ", e);
+        }
+    }
+}

--- a/library/src/main/java/com/rejasupotaro/android/kvs/SharedPreferencesTable.java
+++ b/library/src/main/java/com/rejasupotaro/android/kvs/SharedPreferencesTable.java
@@ -38,7 +38,7 @@ public class SharedPreferencesTable {
         for (Map.Entry<String, ?> entry : sharedPreferences.getAll().entrySet()) {
             String key = entry.getKey();
             String value = entry.getValue().toString();
-            String type = value.getClass().getSimpleName();
+            String type = entry.getValue().getClass().getSimpleName();
 
             data[index][0] = key;
             data[index][1] = value;

--- a/library/src/main/java/com/rejasupotaro/android/kvs/SharedPreferencesTable.java
+++ b/library/src/main/java/com/rejasupotaro/android/kvs/SharedPreferencesTable.java
@@ -1,0 +1,67 @@
+package com.rejasupotaro.android.kvs;
+
+import android.content.SharedPreferences;
+
+import com.jakewharton.fliptables.FlipTable;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class SharedPreferencesTable {
+    private String name;
+    private List<Row> rows = new ArrayList<>();
+
+    public SharedPreferencesTable(String name, SharedPreferences sharedPreferences) {
+        this.name = name;
+
+        for (Map.Entry<String, ?> entry : sharedPreferences.getAll().entrySet()) {
+            String keyName = entry.getKey();
+            String valueType = entry.getValue().getClass().getSimpleName();
+            rows.add(new Row(keyName, valueType));
+        }
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public List<Row> getRows() {
+        return rows;
+    }
+
+    private String[][] toArray(List<Row> rows) {
+        String[][] data = new String[rows.size()][2];
+        for (int i = 0; i < rows.size(); i++) {
+            Row column = rows.get(i);
+            data[i][0] = column.getKey();
+            data[i][1] = column.getValue();
+        }
+        return data;
+    }
+
+    @Override
+    public String toString() {
+        String[] header = {name, ""};
+        return FlipTable.of(header, toArray(rows));
+    }
+
+    public static class Row {
+        private String key;
+        private String value;
+
+        public Row(String key, String value) {
+            this.key = key;
+            this.value = value;
+        }
+
+        public String getKey() {
+            return key;
+        }
+
+        public String getValue() {
+            return value;
+        }
+    }
+}
+

--- a/library/src/main/java/com/rejasupotaro/android/kvs/SharedPreferencesTable.java
+++ b/library/src/main/java/com/rejasupotaro/android/kvs/SharedPreferencesTable.java
@@ -4,28 +4,19 @@ import android.content.SharedPreferences;
 
 import com.jakewharton.fliptables.FlipTable;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 
 public class SharedPreferencesTable {
-    private static final String[] HEADER = {"Key", "Type"};
+    private static final String[] HEADER = {"Key", "Value", "Type"};
 
     private SharedPreferences sharedPreferences;
     private String name;
     private String path;
-    private List<Row> rows = new ArrayList<>();
 
     public SharedPreferencesTable(SharedPreferences sharedPreferences, String name, String path) {
         this.sharedPreferences = sharedPreferences;
         this.name = name;
         this.path = path;
-
-        for (Map.Entry<String, ?> entry : sharedPreferences.getAll().entrySet()) {
-            String keyName = entry.getKey();
-            String valueType = entry.getValue().getClass().getSimpleName();
-            rows.add(new Row(keyName, valueType));
-        }
     }
 
     public SharedPreferences getSharedPreferences() {
@@ -40,17 +31,22 @@ public class SharedPreferencesTable {
         return path;
     }
 
-    public List<Row> getRows() {
-        return rows;
-    }
+    private String[][] toArray() {
+        String[][] data = new String[sharedPreferences.getAll().size()][3];
 
-    private String[][] toArray(List<Row> rows) {
-        String[][] data = new String[rows.size()][2];
-        for (int i = 0; i < rows.size(); i++) {
-            Row column = rows.get(i);
-            data[i][0] = column.getKey();
-            data[i][1] = column.getValue();
+        int index = 0;
+        for (Map.Entry<String, ?> entry : sharedPreferences.getAll().entrySet()) {
+            String key = entry.getKey();
+            String value = entry.getValue().toString();
+            String type = value.getClass().getSimpleName();
+
+            data[index][0] = key;
+            data[index][1] = value;
+            data[index][2] = type;
+
+            index++;
         }
+
         return data;
     }
 
@@ -59,25 +55,7 @@ public class SharedPreferencesTable {
         return String.format("\n\n  name: %s\n  path: %s\n%s\n",
                 name,
                 path,
-                FlipTable.of(HEADER, toArray(rows)));
-    }
-
-    public static class Row {
-        private String key;
-        private String value;
-
-        public Row(String key, String value) {
-            this.key = key;
-            this.value = value;
-        }
-
-        public String getKey() {
-            return key;
-        }
-
-        public String getValue() {
-            return value;
-        }
+                FlipTable.of(HEADER, toArray()));
     }
 }
 

--- a/library/src/main/java/com/rejasupotaro/android/kvs/SharedPreferencesTable.java
+++ b/library/src/main/java/com/rejasupotaro/android/kvs/SharedPreferencesTable.java
@@ -11,11 +11,15 @@ import java.util.Map;
 public class SharedPreferencesTable {
     private static final String[] HEADER = {"Key", "Type"};
 
+    private SharedPreferences sharedPreferences;
     private String name;
+    private String path;
     private List<Row> rows = new ArrayList<>();
 
-    public SharedPreferencesTable(String name, SharedPreferences sharedPreferences) {
+    public SharedPreferencesTable(SharedPreferences sharedPreferences, String name, String path) {
+        this.sharedPreferences = sharedPreferences;
         this.name = name;
+        this.path = path;
 
         for (Map.Entry<String, ?> entry : sharedPreferences.getAll().entrySet()) {
             String keyName = entry.getKey();
@@ -24,8 +28,16 @@ public class SharedPreferencesTable {
         }
     }
 
+    public SharedPreferences getSharedPreferences() {
+        return sharedPreferences;
+    }
+
     public String getName() {
         return name;
+    }
+
+    public String getPath() {
+        return path;
     }
 
     public List<Row> getRows() {
@@ -44,8 +56,9 @@ public class SharedPreferencesTable {
 
     @Override
     public String toString() {
-        return String.format("\n\n  name: %s\n%s\n",
+        return String.format("\n\n  name: %s\n  path: %s\n%s\n",
                 name,
+                path,
                 FlipTable.of(HEADER, toArray(rows)));
     }
 

--- a/library/src/main/java/com/rejasupotaro/android/kvs/SharedPreferencesTable.java
+++ b/library/src/main/java/com/rejasupotaro/android/kvs/SharedPreferencesTable.java
@@ -9,6 +9,8 @@ import java.util.List;
 import java.util.Map;
 
 public class SharedPreferencesTable {
+    private static final String[] HEADER = {"Key", "Type"};
+
     private String name;
     private List<Row> rows = new ArrayList<>();
 
@@ -42,8 +44,9 @@ public class SharedPreferencesTable {
 
     @Override
     public String toString() {
-        String[] header = {name, ""};
-        return FlipTable.of(header, toArray(rows));
+        return String.format("\n\n  name: %s\n%s\n",
+                name,
+                FlipTable.of(HEADER, toArray(rows)));
     }
 
     public static class Row {

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -2,8 +2,8 @@ apply plugin: 'com.android.application'
 apply plugin: 'android-apt'
 
 android {
-    compileSdkVersion 21
-    buildToolsVersion "21.1.2"
+    compileSdkVersion 23
+    buildToolsVersion "23.0.1"
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_7
@@ -12,7 +12,7 @@ android {
 
     defaultConfig {
         minSdkVersion 15
-        targetSdkVersion 21
+        targetSdkVersion 23
         versionCode 1
         versionName "1.0"
 
@@ -40,7 +40,7 @@ dependencies {
     apt project(':compiler')
     compile project(':library')
 
-    compile 'com.android.support:appcompat-v7:21.0.3'
+    compile 'com.android.support:appcompat-v7:23.0.1'
 
     apt 'com.jakewharton:butterknife:7.0.1-compiler'
     compile 'com.jakewharton:butterknife:7.0.1'

--- a/sample/src/androidTest/java/com/example/android/kvs/ExamplePrefsTest.java
+++ b/sample/src/androidTest/java/com/example/android/kvs/ExamplePrefsTest.java
@@ -23,89 +23,77 @@ public class ExamplePrefsTest {
     @Before
     public void setup() {
         Context context = InstrumentationRegistry.getTargetContext();
-        prefs = ExamplePrefsSchema.create(context);
+        prefs = ExamplePrefsSchema.get(context);
     }
 
     @Test
-    public void checkWhetherTypeIntWorks() {
+    public void checkTypeLongWorks() {
         prefs.clear();
-        assertFalse(prefs.hasIntValue());
+        assertFalse(prefs.hasUserId());
 
-        prefs.putIntValue(999);
-        assertTrue(prefs.hasIntValue());
-        assertThat(prefs.getIntValue(), is(999));
+        prefs.putUserId(99999999999L);
+        assertTrue(prefs.hasUserId());
+        assertThat(prefs.getUserId(), is(99999999999L));
 
-        prefs.removeIntValue();
-        assertFalse(prefs.hasIntValue());
+        prefs.removeUserId();
+        assertFalse(prefs.hasUserId());
     }
 
     @Test
-    public void checkWhetherTypeLongWorks() {
+    public void checkTypeStringWorks() {
         prefs.clear();
-        assertFalse(prefs.hasLongValue());
+        assertFalse(prefs.hasUserName());
+        assertThat(prefs.getUserName(), is("guest"));
 
-        prefs.putLongValue(99999999999L);
-        assertTrue(prefs.hasLongValue());
-        assertThat(prefs.getLongValue(), is(99999999999L));
+        prefs.putUserName("rejasupotaro");
+        assertTrue(prefs.hasUserName());
+        assertThat(prefs.getUserName(), is("rejasupotaro"));
 
-        prefs.removeLongValue();
-        assertFalse(prefs.hasLongValue());
+        prefs.removeUserName();
+        assertFalse(prefs.hasUserName());
     }
 
     @Test
-    public void checkWhetherTypeFloatWorks() {
+    public void checkTypeIntWorks() {
         prefs.clear();
-        assertFalse(prefs.hasFloatValue());
+        assertFalse(prefs.hasUserAge());
 
-        prefs.putFloatValue(99.99f);
-        assertTrue(prefs.hasFloatValue());
-        assertThat(prefs.getFloatValue(), is(99.99f));
+        prefs.putUserAge(26);
+        assertTrue(prefs.hasUserAge());
+        assertThat(prefs.getUserAge(), is(26));
 
-        prefs.removeFloatValue();
-        assertFalse(prefs.hasFloatValue());
+        prefs.removeUserAge();
+        assertFalse(prefs.hasUserAge());
     }
 
     @Test
-    public void checkWhetherTypeBooleanWorks() {
+    public void checkTypeBooleanWorks() {
         prefs.clear();
-        assertFalse(prefs.hasBooleanValue());
+        assertFalse(prefs.hasGuestFlag());
 
-        prefs.putBooleanValue(true);
-        assertTrue(prefs.hasBooleanValue());
-        assertThat(prefs.getBooleanValue(), is(true));
+        prefs.putGuestFlag(true);
+        assertTrue(prefs.hasGuestFlag());
+        assertThat(prefs.getGuestFlag(), is(true));
 
-        prefs.removeBooleanValue();
-        assertFalse(prefs.hasBooleanValue());
+        prefs.removeGuestFlag();
+        assertFalse(prefs.hasGuestFlag());
     }
 
-    @Test
-    public void checkWhetherTypeStringWorks() {
-        prefs.clear();
-        assertFalse(prefs.hasStringValue());
-        assertThat(prefs.getStringValue(), is("guest"));
-
-        prefs.putStringValue("Java");
-        assertTrue(prefs.hasStringValue());
-        assertThat(prefs.getStringValue(), is("Java"));
-
-        prefs.removeStringValue();
-        assertFalse(prefs.hasStringValue());
-    }
 
     @Test
-    public void checkWhetherTypeStringSetWorks() {
+    public void checkTypeStringSetWorks() {
         prefs.clear();
-        assertFalse(prefs.hasStringSet());
+        assertFalse(prefs.hasSearchHistory());
 
-        prefs.putStringSet(new HashSet<String>() {{
+        prefs.putSearchHistory(new HashSet<String>() {{
             add("JAVA");
             add("+");
             add("YOU");
         }});
-        assertTrue(prefs.hasStringSet());
-        assertThat(prefs.getStringSet().size(), is(3));
+        assertTrue(prefs.hasSearchHistory());
+        assertThat(prefs.getSearchHistory().size(), is(3));
 
-        prefs.removeStringSet();
-        assertFalse(prefs.hasStringSet());
+        prefs.removeSearchHistory();
+        assertFalse(prefs.hasSearchHistory());
     }
 }

--- a/sample/src/main/java/com/example/android/kvs/ExamplePrefsSchema.java
+++ b/sample/src/main/java/com/example/android/kvs/ExamplePrefsSchema.java
@@ -12,20 +12,18 @@ import java.util.Set;
 public abstract class ExamplePrefsSchema extends PrefSchema {
     public static ExamplePrefs prefs;
 
-    @Key("int_value")
-    protected int intValue;
-    @Key("long_value")
-    protected long longValue;
-    @Key("float_value")
-    protected float floatValue;
-    @Key("boolean_value")
-    protected boolean booleanValue;
-    @Key("string_value")
-    protected String stringValue = "guest";
-    @Key("string_set")
-    protected Set<String> stringSet;
+    @Key("user_id")
+    long userId;
+    @Key("user_name")
+    String userName = "guest";
+    @Key("user_age")
+    int userAge;
+    @Key("guest_flag")
+    boolean guestFlag;
+    @Key("search_history")
+    Set<String> searchHistory;
 
-    public static synchronized ExamplePrefs create(Context context) {
+    public static synchronized ExamplePrefs get(Context context) {
         if (prefs == null) {
             prefs = new ExamplePrefs(context);
         }

--- a/sample/src/main/java/com/example/android/kvs/MainActivity.java
+++ b/sample/src/main/java/com/example/android/kvs/MainActivity.java
@@ -63,7 +63,7 @@ public class MainActivity extends ActionBarActivity {
         Set<String> languages = prefs.getSearchHistory();
         searchHistoryTextView.setText(languages.toString());
 
-        List<SharedPreferencesTable> tables = SharedPreferencesInfo.getAllPrefsAsTable(this);
+        List<SharedPreferencesTable> tables = SharedPreferencesInfo.getAll(this);
         for (SharedPreferencesTable table : tables) {
             Log.d("DEBUG", table.toString());
         }

--- a/sample/src/main/java/com/example/android/kvs/MainActivity.java
+++ b/sample/src/main/java/com/example/android/kvs/MainActivity.java
@@ -11,24 +11,23 @@ import com.rejasupotaro.android.kvs.SharedPreferencesInfo;
 import com.rejasupotaro.android.kvs.SharedPreferencesTable;
 
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import butterknife.Bind;
 import butterknife.ButterKnife;
 
 public class MainActivity extends ActionBarActivity {
-    @Bind(R.id.int_value_text)
-    TextView intValueTextView;
     @Bind(R.id.long_value_text)
-    TextView longValueTextView;
-    @Bind(R.id.float_value_text)
-    TextView floatValueTextView;
-    @Bind(R.id.boolean_value_text)
-    TextView booleanValueTextView;
+    TextView userIdTextView;
     @Bind(R.id.string_value_text)
-    TextView stringValueTextView;
-    @Bind(R.id.string_set_text)
-    TextView stringSetTextView;
+    TextView userNameTextView;
+    @Bind(R.id.int_value_text)
+    TextView userAgeTextView;
+    @Bind(R.id.boolean_value_text)
+    TextView guestFlagTextView;
+    @Bind(R.id.string_set_value_text)
+    TextView searchHistoryTextView;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -39,36 +38,33 @@ public class MainActivity extends ActionBarActivity {
     }
 
     private void setupViews() {
-        ExamplePrefs prefs = ExamplePrefsSchema.create(this);
+        ExamplePrefs prefs = ExamplePrefsSchema.get(this);
 
-        prefs.putIntValue(1);
-        long intValue = prefs.getIntValue();
-        intValueTextView.setText("" + intValue);
+        prefs.putUserId(1L);
+        long id = prefs.getUserId();
+        userIdTextView.setText("" + id);
 
-        prefs.putLongValue(1);
-        long longValue = prefs.getLongValue();
-        longValueTextView.setText("" + longValue);
+        prefs.putGuestFlag(false);
+        boolean isGuest = prefs.getGuestFlag();
+        guestFlagTextView.setText("" + isGuest);
 
-        prefs.putFloatValue(1.0f);
-        float floatValue = prefs.getFloatValue();
-        floatValueTextView.setText("" + floatValue);
+        prefs.putUserName("rejasupotaro");
+        userNameTextView.setText(prefs.getUserName());
 
-        prefs.putBooleanValue(true);
-        boolean booleanValue = prefs.getBooleanValue();
-        booleanValueTextView.setText("" + booleanValue);
+        prefs.putUserAge(26);
+        long age = prefs.getUserAge();
+        userAgeTextView.setText("" + age);
 
-        stringValueTextView.setText(prefs.getStringValue());
-
-        prefs.putStringSet(new HashSet<String>() {{
-            add("JAVA");
-            add("+");
-            add("YOU");
+        prefs.putSearchHistory(new HashSet<String>() {{
+            add("turkey gravy");
+            add("pork stake");
+            add("banana cake");
         }});
-        Set<String> stringSet = prefs.getStringSet();
-        stringSetTextView.setText(stringSet.toString());
+        Set<String> languages = prefs.getSearchHistory();
+        searchHistoryTextView.setText(languages.toString());
 
-        for (SharedPreferencesTable table : SharedPreferencesInfo.getAllPrefsAsTable(this)) {
-            Log.d("DEBUG", "");
+        List<SharedPreferencesTable> tables = SharedPreferencesInfo.getAllPrefsAsTable(this);
+        for (SharedPreferencesTable table : tables) {
             Log.d("DEBUG", table.toString());
         }
     }

--- a/sample/src/main/java/com/example/android/kvs/MainActivity.java
+++ b/sample/src/main/java/com/example/android/kvs/MainActivity.java
@@ -2,9 +2,13 @@ package com.example.android.kvs;
 
 import android.os.Bundle;
 import android.support.v7.app.ActionBarActivity;
+import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.widget.TextView;
+
+import com.rejasupotaro.android.kvs.SharedPreferencesInfo;
+import com.rejasupotaro.android.kvs.SharedPreferencesTable;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -62,6 +66,11 @@ public class MainActivity extends ActionBarActivity {
         }});
         Set<String> stringSet = prefs.getStringSet();
         stringSetTextView.setText(stringSet.toString());
+
+        for (SharedPreferencesTable table : SharedPreferencesInfo.getAllPrefsAsTable(this)) {
+            Log.d("DEBUG", "");
+            Log.d("DEBUG", table.toString());
+        }
     }
 
     @Override

--- a/sample/src/main/res/layout/activity_main.xml
+++ b/sample/src/main/res/layout/activity_main.xml
@@ -1,30 +1,29 @@
 <GridLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:columnCount="2"
+    android:columnCount="3"
     android:padding="@dimen/spacing_large">
 
+    <!-- header -->
     <TextView
         style="@style/GridCell"
-        android:text="@string/type"
+        android:text="Key"
         android:textStyle="bold" />
 
     <TextView
         style="@style/GridCell"
-        android:text="@string/value"
+        android:text="Value"
         android:textStyle="bold" />
 
     <TextView
         style="@style/GridCell"
-        android:text="@string/_int" />
+        android:text="Type"
+        android:textStyle="bold" />
 
-    <TextView
-        android:id="@+id/int_value_text"
-        style="@style/GridCell" />
-
+    <!-- long -->
     <TextView
         style="@style/GridCell"
-        android:text="@string/_long" />
+        android:text="id" />
 
     <TextView
         android:id="@+id/long_value_text"
@@ -32,23 +31,12 @@
 
     <TextView
         style="@style/GridCell"
-        android:text="@string/_float" />
+        android:text="long" />
 
-    <TextView
-        android:id="@+id/float_value_text"
-        style="@style/GridCell" />
-
+    <!-- string -->
     <TextView
         style="@style/GridCell"
-        android:text="@string/_boolean" />
-
-    <TextView
-        android:id="@+id/boolean_value_text"
-        style="@style/GridCell" />
-
-    <TextView
-        style="@style/GridCell"
-        android:text="@string/string" />
+        android:text="name" />
 
     <TextView
         android:id="@+id/string_value_text"
@@ -56,9 +44,44 @@
 
     <TextView
         style="@style/GridCell"
-        android:text="@string/string" />
+        android:text="string" />
+
+    <!-- int -->
+    <TextView
+        style="@style/GridCell"
+        android:text="age" />
 
     <TextView
-        android:id="@+id/string_set_text"
+        android:id="@+id/int_value_text"
         style="@style/GridCell" />
+
+    <TextView
+        style="@style/GridCell"
+        android:text="int" />
+
+    <!-- boolean -->
+    <TextView
+        style="@style/GridCell"
+        android:text="guest?" />
+
+    <TextView
+        android:id="@+id/boolean_value_text"
+        style="@style/GridCell" />
+
+    <TextView
+        style="@style/GridCell"
+        android:text="boolean" />
+
+    <!-- string set -->
+    <TextView
+        style="@style/GridCell"
+        android:text="languages" />
+
+    <TextView
+        android:id="@+id/string_set_value_text"
+        style="@style/GridCell" />
+
+    <TextView
+        style="@style/GridCell"
+        android:text="string_set" />
 </GridLayout>

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -2,12 +2,4 @@
 <resources>
     <string name="app_name">KVS Schema</string>
     <string name="action_settings">Settings</string>
-    <string name="type">Type</string>
-    <string name="value">Value</string>
-    <string name="_int">int</string>
-    <string name="_long">long</string>
-    <string name="_float">float</string>
-    <string name="_boolean">boolean</string>
-    <string name="string">String</string>
-    <string name="string_set">String Set</string>
 </resources>


### PR DESCRIPTION
In this PR, I created `SharedPreferencesInfo` class.
`SharedPreferencesInfo.getAll` method returns a list of `SharedPreferencesTable`. Developers can see the structure of existing shared preferences easily.

```java
SharedPreferencesInfo.getAll();
List<SharedPreferencesTable> tables = SharedPreferencesInfo.getAll(context);
for (SharedPreferencesTable table : tables) {
    Log.d("DEBUG", table.toString());
}
```

```
   name: com.example.android.kvs_preferences
   path: /data/data/com.example.android.kvs/shared_prefs/com.example.android.kvs_preferences.xml
 ╔═══════════╤══════════════╤═════════╗
 ║ Key       │ Value        │ Type    ║
 ╠═══════════╪══════════════╪═════════╣
 ║ user_name │ rejasupotaro │ String  ║
 ╟───────────┼──────────────┼─────────╢
 ║ user_id   │ 1            │ Integer ║
 ╚═══════════╧══════════════╧═════════╝
```

I also updated the documentation about migration. It helps developers to migrate apps.

### Related links

- [Option which uses default preference · Issue #7 · rejasupotaro/kvs-schema](https://github.com/rejasupotaro/kvs-schema/issues/7)
- [JakeWharton/flip-tables](https://github.com/JakeWharton/flip-tables)