### PR TITLE
[Bugfix] Given StringSet is ignored.

### DIFF
--- a/compiler/src/main/java/com/rejasupotaro/android/kvs/internal/SchemaWriter.java
+++ b/compiler/src/main/java/com/rejasupotaro/android/kvs/internal/SchemaWriter.java
@@ -121,8 +121,8 @@ public class SchemaWriter {
             TypeName fieldType = TypeName.BOOLEAN;
             String argTypeOfSuperMethod = "boolean";
 
-            methodSpecs.add(createGetterMethod(fieldType, argTypeOfSuperMethod, keyName, fieldName));
-            methodSpecs.add(createGetterWithDefaultValueMethod(fieldType, argTypeOfSuperMethod, keyName, fieldName, false));
+            methodSpecs.add(createGetterMethodWithDefaultValueMethod(fieldType, argTypeOfSuperMethod, keyName, fieldName));
+            methodSpecs.add(createGetterMethod(fieldType, argTypeOfSuperMethod, keyName, fieldName, false));
             methodSpecs.addAll(createSetterMethod(fieldType, argTypeOfSuperMethod, keyName, fieldName));
             methodSpecs.add(createHasMethod(keyName, fieldName));
             methodSpecs.add(createRemoveMethod(keyName, fieldName));
@@ -137,17 +137,16 @@ public class SchemaWriter {
                     .returns(fieldType)
                     .addStatement("return $N($S, \"\")", superMethodName, keyName)
                     .build());
-
-            methodSpecs.add(createGetterMethod(fieldType, argTypeOfSuperMethod, keyName, fieldName));
             methodSpecs.addAll(createSetterMethod(fieldType, argTypeOfSuperMethod, keyName, fieldName));
+            methodSpecs.add(createGetterMethodWithDefaultValueMethod(fieldType, argTypeOfSuperMethod, keyName, fieldName));
             methodSpecs.add(createHasMethod(keyName, fieldName));
             methodSpecs.add(createRemoveMethod(keyName, fieldName));
         } else if (t.equals(TypeName.FLOAT)) {
             TypeName fieldType = TypeName.FLOAT;
             String argTypeOfSuperMethod = "float";
 
-            methodSpecs.add(createGetterMethod(fieldType, argTypeOfSuperMethod, keyName, fieldName));
-            methodSpecs.add(createGetterWithDefaultValueMethod(fieldType, argTypeOfSuperMethod, keyName, fieldName, 0f));
+            methodSpecs.add(createGetterMethod(fieldType, argTypeOfSuperMethod, keyName, fieldName, 0f));
+            methodSpecs.add(createGetterMethodWithDefaultValueMethod(fieldType, argTypeOfSuperMethod, keyName, fieldName));
             methodSpecs.addAll(createSetterMethod(fieldType, argTypeOfSuperMethod, keyName, fieldName));
             methodSpecs.add(createHasMethod(keyName, fieldName));
             methodSpecs.add(createRemoveMethod(keyName, fieldName));
@@ -155,8 +154,8 @@ public class SchemaWriter {
             TypeName fieldType = TypeName.INT;
             String argTypeOfSuperMethod = "int";
 
-            methodSpecs.add(createGetterMethod(fieldType, argTypeOfSuperMethod, keyName, fieldName));
-            methodSpecs.add(createGetterWithDefaultValueMethod(fieldType, argTypeOfSuperMethod, keyName, fieldName, 0));
+            methodSpecs.add(createGetterMethod(fieldType, argTypeOfSuperMethod, keyName, fieldName, 0));
+            methodSpecs.add(createGetterMethodWithDefaultValueMethod(fieldType, argTypeOfSuperMethod, keyName, fieldName));
             methodSpecs.addAll(createSetterMethod(fieldType, argTypeOfSuperMethod, keyName, fieldName));
             methodSpecs.add(createHasMethod(keyName, fieldName));
             methodSpecs.add(createRemoveMethod(keyName, fieldName));
@@ -164,8 +163,8 @@ public class SchemaWriter {
             TypeName fieldType = TypeName.LONG;
             String argTypeOfSuperMethod = "long";
 
-            methodSpecs.add(createGetterMethod(fieldType, argTypeOfSuperMethod, keyName, fieldName));
-            methodSpecs.add(createGetterWithDefaultValueMethod(fieldType, argTypeOfSuperMethod, keyName, fieldName, 0L));
+            methodSpecs.add(createGetterMethod(fieldType, argTypeOfSuperMethod, keyName, fieldName, 0L));
+            methodSpecs.add(createGetterMethodWithDefaultValueMethod(fieldType, argTypeOfSuperMethod, keyName, fieldName));
             methodSpecs.addAll(createSetterMethod(fieldType, argTypeOfSuperMethod, keyName, fieldName));
             methodSpecs.add(createHasMethod(keyName, fieldName));
             methodSpecs.add(createRemoveMethod(keyName, fieldName));
@@ -180,8 +179,7 @@ public class SchemaWriter {
                     .returns(fieldType)
                     .addStatement("return $N($S, new $T<String>())", superMethodName, keyName, ClassName.get(HashSet.class))
                     .build());
-
-            methodSpecs.add(createGetterMethod(fieldType, argTypeOfSuperMethod, keyName, fieldName));
+            methodSpecs.add(createGetterMethodWithDefaultValueMethod(fieldType, argTypeOfSuperMethod, keyName, fieldName));
             methodSpecs.addAll(createSetterMethod(fieldType, argTypeOfSuperMethod, keyName, fieldName));
             methodSpecs.add(createHasMethod(keyName, fieldName));
             methodSpecs.add(createRemoveMethod(keyName, fieldName));
@@ -193,25 +191,25 @@ public class SchemaWriter {
         return methodSpecs;
     }
 
-    private MethodSpec createGetterMethod(TypeName fieldType, String argTypeOfSuperMethod, String keyName, String fieldName) {
-        String methodName = "get" + StringUtils.capitalize(fieldName);
-        String superMethodName = "get" + StringUtils.capitalize(argTypeOfSuperMethod);
-        String parameterName = "defaultValue";
-        return MethodSpec.methodBuilder(methodName)
-                .addModifiers(Modifier.PUBLIC)
-                .addParameter(fieldType, parameterName)
-                .returns(fieldType)
-                .addStatement("return $N($S, $N)", superMethodName, keyName, parameterName)
-                .build();
-    }
-
-    private MethodSpec createGetterWithDefaultValueMethod(TypeName fieldType, String argTypeOfSuperMethod, String keyName, String fieldName, Object defaultValue) {
+    private MethodSpec createGetterMethod(TypeName fieldType, String argTypeOfSuperMethod, String keyName, String fieldName, Object defaultValue) {
         String methodName = "get" + StringUtils.capitalize(fieldName);
         String superMethodName = "get" + StringUtils.capitalize(argTypeOfSuperMethod);
         return MethodSpec.methodBuilder(methodName)
                 .addModifiers(Modifier.PUBLIC)
                 .returns(fieldType)
                 .addStatement("return $N($S, $L)", superMethodName, keyName, defaultValue)
+                .build();
+    }
+
+    private MethodSpec createGetterMethodWithDefaultValueMethod(TypeName fieldType, String argTypeOfSuperMethod, String keyName, String fieldName) {
+        String methodName = "get" + StringUtils.capitalize(fieldName);
+        String superMethodName = "get" + StringUtils.capitalize(argTypeOfSuperMethod);
+        String parameterName = "defValue";
+        return MethodSpec.methodBuilder(methodName)
+                .addModifiers(Modifier.PUBLIC)
+                .addParameter(fieldType, parameterName)
+                .returns(fieldType)
+                .addStatement("return $N($S, $N)", superMethodName, keyName, parameterName)
                 .build();
     }
 

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'android-apt'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    buildToolsVersion "23.0.2"
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_7
@@ -27,7 +27,10 @@ android {
         exclude 'META-INF/services/javax.annotation.processing.Processor'
         exclude 'META-INF/LICENSE.txt'
         exclude 'META-INF/NOTICE.txt'
+        exclude 'asm-license.txt'
+        exclude 'NOTICE'
         exclude 'LICENSE.txt'
+        exclude 'LICENSE'
     }
 
     testOptions {
@@ -40,7 +43,7 @@ dependencies {
     apt project(':compiler')
     compile project(':library')
 
-    compile 'com.android.support:appcompat-v7:23.0.1'
+    compile 'com.android.support:appcompat-v7:23.2.0'
 
     apt 'com.jakewharton:butterknife:7.0.1-compiler'
     compile 'com.jakewharton:butterknife:7.0.1'
@@ -49,9 +52,11 @@ dependencies {
     androidTestCompile 'org.mockito:mockito-core:1.9.5'
     androidTestCompile 'com.google.dexmaker:dexmaker:1.1'
     androidTestCompile 'com.google.dexmaker:dexmaker-mockito:1.1'
-    androidTestCompile 'org.hamcrest:hamcrest-integration:1.3'
-    androidTestCompile 'org.hamcrest:hamcrest-core:1.3'
-    androidTestCompile 'org.hamcrest:hamcrest-library:1.3'
+    androidTestCompile 'com.squareup.assertj:assertj-android:1.1.1'
+}
+
+configurations.all {
+    resolutionStrategy.force 'com.android.support:support-annotations:22.1.0'
 }
 
 android.applicationVariants.all { variant ->

--- a/example/src/androidTest/java/com/example/android/kvs/ExamplePrefsTest.java
+++ b/example/src/androidTest/java/com/example/android/kvs/ExamplePrefsTest.java
@@ -10,10 +10,7 @@ import org.junit.runner.RunWith;
 
 import java.util.HashSet;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(AndroidJUnit4.class)
 public class ExamplePrefsTest {
@@ -29,71 +26,71 @@ public class ExamplePrefsTest {
     @Test
     public void checkTypeLongWorks() {
         prefs.clear();
-        assertFalse(prefs.hasUserId());
+        assertThat(prefs.hasUserId()).isFalse();
 
         prefs.putUserId(99999999999L);
-        assertTrue(prefs.hasUserId());
-        assertThat(prefs.getUserId(), is(99999999999L));
+        assertThat(prefs.hasUserId()).isTrue();
+        assertThat(prefs.getUserId()).isEqualTo(99999999999L);
 
         prefs.removeUserId();
-        assertFalse(prefs.hasUserId());
+        assertThat(prefs.hasUserId()).isFalse();
     }
 
     @Test
     public void checkTypeStringWorks() {
         prefs.clear();
-        assertFalse(prefs.hasUserName());
-        assertThat(prefs.getUserName("guest"), is("guest"));
+        assertThat(prefs.hasUserName()).isFalse();
+        assertThat(prefs.getUserName("guest")).isEqualTo("guest");
 
         prefs.putUserName("rejasupotaro");
-        assertTrue(prefs.hasUserName());
-        assertThat(prefs.getUserName(), is("rejasupotaro"));
+        assertThat(prefs.hasUserName()).isTrue();
+        assertThat(prefs.getUserName()).isEqualTo("rejasupotaro");
 
         prefs.removeUserName();
-        assertFalse(prefs.hasUserName());
+        assertThat(prefs.hasUserName()).isFalse();
     }
 
     @Test
     public void checkTypeIntWorks() {
         prefs.clear();
-        assertFalse(prefs.hasUserAge());
+        assertThat(prefs.hasUserAge()).isFalse();
 
         prefs.putUserAge(26);
-        assertTrue(prefs.hasUserAge());
-        assertThat(prefs.getUserAge(), is(26));
+        assertThat(prefs.hasUserAge()).isTrue();
+        assertThat(prefs.getUserAge()).isEqualTo(26);
 
         prefs.removeUserAge();
-        assertFalse(prefs.hasUserAge());
+        assertThat(prefs.hasUserAge()).isFalse();
     }
 
     @Test
     public void checkTypeBooleanWorks() {
         prefs.clear();
-        assertFalse(prefs.hasGuestFlag());
+        assertThat(prefs.hasGuestFlag()).isFalse();
 
         prefs.putGuestFlag(true);
-        assertTrue(prefs.hasGuestFlag());
-        assertThat(prefs.getGuestFlag(), is(true));
+        assertThat(prefs.hasGuestFlag()).isTrue();
+        assertThat(prefs.getGuestFlag()).isTrue();
 
         prefs.removeGuestFlag();
-        assertFalse(prefs.hasGuestFlag());
+        assertThat(prefs.hasGuestFlag()).isFalse();
     }
 
 
     @Test
     public void checkTypeStringSetWorks() {
         prefs.clear();
-        assertFalse(prefs.hasSearchHistory());
+        assertThat(prefs.hasSearchHistory()).isFalse();
 
         prefs.putSearchHistory(new HashSet<String>() {{
             add("JAVA");
             add("+");
             add("YOU");
         }});
-        assertTrue(prefs.hasSearchHistory());
-        assertThat(prefs.getSearchHistory().size(), is(3));
+        assertThat(prefs.hasSearchHistory()).isTrue();
+        assertThat(prefs.getSearchHistory().size()).isEqualTo(3);
 
         prefs.removeSearchHistory();
-        assertFalse(prefs.hasSearchHistory());
+        assertThat(prefs.hasSearchHistory()).isFalse();
     }
 }

--- a/example/src/androidTest/java/com/example/android/kvs/ExamplePrefsTest.java
+++ b/example/src/androidTest/java/com/example/android/kvs/ExamplePrefsTest.java
@@ -40,7 +40,7 @@ public class ExamplePrefsTest {
     }
 
     @Test
-    public void checkTypeLongWorks() {
+    public void longWorks() {
         assertThat(prefs.hasUserId()).isFalse();
 
         prefs.putUserId(99999999999L);
@@ -52,7 +52,7 @@ public class ExamplePrefsTest {
     }
 
     @Test
-    public void checkTypeStringWorks() {
+    public void stringWorks() {
         assertThat(prefs.hasUserName()).isFalse();
         assertThat(prefs.getUserName("guest")).isEqualTo("guest");
 
@@ -65,7 +65,7 @@ public class ExamplePrefsTest {
     }
 
     @Test
-    public void checkTypeIntWorks() {
+    public void intWorks() {
         assertThat(prefs.hasUserAge()).isFalse();
 
         prefs.putUserAge(26);
@@ -77,7 +77,7 @@ public class ExamplePrefsTest {
     }
 
     @Test
-    public void checkTypeBooleanWorks() {
+    public void booleanWorks() {
         assertThat(prefs.hasGuestFlag()).isFalse();
 
         prefs.putGuestFlag(true);
@@ -90,7 +90,7 @@ public class ExamplePrefsTest {
 
 
     @Test
-    public void checkTypeStringSetWorks() {
+    public void stringSetWorks() {
         assertThat(prefs.hasSearchHistory()).isFalse();
 
         prefs.putSearchHistory(new HashSet<String>() {{

--- a/example/src/androidTest/java/com/example/android/kvs/ExamplePrefsTest.java
+++ b/example/src/androidTest/java/com/example/android/kvs/ExamplePrefsTest.java
@@ -15,17 +15,32 @@ import static org.assertj.core.api.Assertions.assertThat;
 @RunWith(AndroidJUnit4.class)
 public class ExamplePrefsTest {
 
+    private Context context;
     private ExamplePrefs prefs;
 
     @Before
     public void setup() {
-        Context context = InstrumentationRegistry.getTargetContext();
-        prefs = ExamplePrefs.get(context);
+        this.context = InstrumentationRegistry.getTargetContext();
+        this.prefs = ExamplePrefs.get(context);
+        prefs.clear();
+    }
+
+    @Test
+    public void getSingletonInstance() {
+        {
+            ExamplePrefs prefs1 = new ExamplePrefs(context);
+            ExamplePrefs prefs2 = new ExamplePrefs(context);
+            assertThat(prefs1).isNotEqualTo(prefs2);
+        }
+        {
+            ExamplePrefs prefs1 = ExamplePrefs.get(context);
+            ExamplePrefs prefs2 = ExamplePrefs.get(context);
+            assertThat(prefs1).isEqualTo(prefs2);
+        }
     }
 
     @Test
     public void checkTypeLongWorks() {
-        prefs.clear();
         assertThat(prefs.hasUserId()).isFalse();
 
         prefs.putUserId(99999999999L);
@@ -38,7 +53,6 @@ public class ExamplePrefsTest {
 
     @Test
     public void checkTypeStringWorks() {
-        prefs.clear();
         assertThat(prefs.hasUserName()).isFalse();
         assertThat(prefs.getUserName("guest")).isEqualTo("guest");
 
@@ -52,7 +66,6 @@ public class ExamplePrefsTest {
 
     @Test
     public void checkTypeIntWorks() {
-        prefs.clear();
         assertThat(prefs.hasUserAge()).isFalse();
 
         prefs.putUserAge(26);
@@ -65,7 +78,6 @@ public class ExamplePrefsTest {
 
     @Test
     public void checkTypeBooleanWorks() {
-        prefs.clear();
         assertThat(prefs.hasGuestFlag()).isFalse();
 
         prefs.putGuestFlag(true);
@@ -79,7 +91,6 @@ public class ExamplePrefsTest {
 
     @Test
     public void checkTypeStringSetWorks() {
-        prefs.clear();
         assertThat(prefs.hasSearchHistory()).isFalse();
 
         prefs.putSearchHistory(new HashSet<String>() {{
@@ -89,6 +100,9 @@ public class ExamplePrefsTest {
         }});
         assertThat(prefs.hasSearchHistory()).isTrue();
         assertThat(prefs.getSearchHistory().size()).isEqualTo(3);
+        assertThat(prefs.getSearchHistory().contains("JAVA")).isTrue();
+        assertThat(prefs.getSearchHistory().contains("+")).isTrue();
+        assertThat(prefs.getSearchHistory().contains("YOU")).isTrue();
 
         prefs.removeSearchHistory();
         assertThat(prefs.hasSearchHistory()).isFalse();

--- a/example/src/androidTest/java/com/example/android/kvs/ExamplePrefsTest.java
+++ b/example/src/androidTest/java/com/example/android/kvs/ExamplePrefsTest.java
@@ -42,6 +42,7 @@ public class ExamplePrefsTest {
     @Test
     public void longWorks() {
         assertThat(prefs.hasUserId()).isFalse();
+        assertThat(prefs.getUserId(-1L)).isEqualTo(-1L);
 
         prefs.putUserId(99999999999L);
         assertThat(prefs.hasUserId()).isTrue();
@@ -67,6 +68,7 @@ public class ExamplePrefsTest {
     @Test
     public void intWorks() {
         assertThat(prefs.hasUserAge()).isFalse();
+        assertThat(prefs.getUserAge(-1)).isEqualTo(-1);
 
         prefs.putUserAge(26);
         assertThat(prefs.hasUserAge()).isTrue();
@@ -79,6 +81,7 @@ public class ExamplePrefsTest {
     @Test
     public void booleanWorks() {
         assertThat(prefs.hasGuestFlag()).isFalse();
+        assertThat(prefs.getGuestFlag(true)).isTrue();
 
         prefs.putGuestFlag(true);
         assertThat(prefs.hasGuestFlag()).isTrue();
@@ -92,6 +95,9 @@ public class ExamplePrefsTest {
     @Test
     public void stringSetWorks() {
         assertThat(prefs.hasSearchHistory()).isFalse();
+        assertThat(prefs.getSearchHistory(new HashSet<String>() {{
+            add("Kotlin");
+        }}).size()).isEqualTo(1);
 
         prefs.putSearchHistory(new HashSet<String>() {{
             add("JAVA");

--- a/library/src/main/java/com/rejasupotaro/android/kvs/PrefsSchema.java
+++ b/library/src/main/java/com/rejasupotaro/android/kvs/PrefsSchema.java
@@ -3,7 +3,6 @@ package com.rejasupotaro.android.kvs;
 import android.content.Context;
 import android.content.SharedPreferences;
 
-import java.util.HashSet;
 import java.util.Set;
 
 public abstract class PrefsSchema {
@@ -62,7 +61,7 @@ public abstract class PrefsSchema {
     }
 
     protected Set<String> getStringSet(String key, Set<String> defValue) {
-        return prefs.getStringSet(key, new HashSet<String>());
+        return prefs.getStringSet(key, defValue);
     }
 
     protected boolean has(String key) {


### PR DESCRIPTION
# Changes

* Introduced AssertJ.
 * AssertJ provdes fluent interfaces. It helps developers to write tests.
* Added tests for `ExamplePrefs.get` method and `ExamplePrefs.get*(defValue)` method.
* While writing tests, I found a bug that given hashset is ignored.
 * It was fixed in https://github.com/rejasupotaro/kvs-schema/commit/73ffb5e9444f80b379ee36436e3fe0d13f1c0fe3.