### PR TITLE
Fix default value of float field was "0.0" in generated code.

### DIFF
--- a/compiler/src/main/java/com/rejasupotaro/android/kvs/internal/SchemaWriter.java
+++ b/compiler/src/main/java/com/rejasupotaro/android/kvs/internal/SchemaWriter.java
@@ -122,7 +122,7 @@ public class SchemaWriter {
             String argTypeOfSuperMethod = "boolean";
 
             methodSpecs.add(createGetterMethodWithDefaultValueMethod(fieldType, argTypeOfSuperMethod, keyName, fieldName));
-            methodSpecs.add(createGetterMethod(fieldType, argTypeOfSuperMethod, keyName, fieldName, false));
+            methodSpecs.add(createGetterMethod(fieldType, argTypeOfSuperMethod, keyName, fieldName, "false"));
             methodSpecs.addAll(createSetterMethod(fieldType, argTypeOfSuperMethod, keyName, fieldName));
             methodSpecs.add(createHasMethod(keyName, fieldName));
             methodSpecs.add(createRemoveMethod(keyName, fieldName));
@@ -145,7 +145,7 @@ public class SchemaWriter {
             TypeName fieldType = TypeName.FLOAT;
             String argTypeOfSuperMethod = "float";
 
-            methodSpecs.add(createGetterMethod(fieldType, argTypeOfSuperMethod, keyName, fieldName, 0f));
+            methodSpecs.add(createGetterMethod(fieldType, argTypeOfSuperMethod, keyName, fieldName, "0.0F"));
             methodSpecs.add(createGetterMethodWithDefaultValueMethod(fieldType, argTypeOfSuperMethod, keyName, fieldName));
             methodSpecs.addAll(createSetterMethod(fieldType, argTypeOfSuperMethod, keyName, fieldName));
             methodSpecs.add(createHasMethod(keyName, fieldName));
@@ -154,7 +154,7 @@ public class SchemaWriter {
             TypeName fieldType = TypeName.INT;
             String argTypeOfSuperMethod = "int";
 
-            methodSpecs.add(createGetterMethod(fieldType, argTypeOfSuperMethod, keyName, fieldName, 0));
+            methodSpecs.add(createGetterMethod(fieldType, argTypeOfSuperMethod, keyName, fieldName, "0"));
             methodSpecs.add(createGetterMethodWithDefaultValueMethod(fieldType, argTypeOfSuperMethod, keyName, fieldName));
             methodSpecs.addAll(createSetterMethod(fieldType, argTypeOfSuperMethod, keyName, fieldName));
             methodSpecs.add(createHasMethod(keyName, fieldName));
@@ -163,7 +163,7 @@ public class SchemaWriter {
             TypeName fieldType = TypeName.LONG;
             String argTypeOfSuperMethod = "long";
 
-            methodSpecs.add(createGetterMethod(fieldType, argTypeOfSuperMethod, keyName, fieldName, 0L));
+            methodSpecs.add(createGetterMethod(fieldType, argTypeOfSuperMethod, keyName, fieldName, "0L"));
             methodSpecs.add(createGetterMethodWithDefaultValueMethod(fieldType, argTypeOfSuperMethod, keyName, fieldName));
             methodSpecs.addAll(createSetterMethod(fieldType, argTypeOfSuperMethod, keyName, fieldName));
             methodSpecs.add(createHasMethod(keyName, fieldName));
@@ -191,7 +191,7 @@ public class SchemaWriter {
         return methodSpecs;
     }
 
-    private MethodSpec createGetterMethod(TypeName fieldType, String argTypeOfSuperMethod, String keyName, String fieldName, Object defaultValue) {
+    private MethodSpec createGetterMethod(TypeName fieldType, String argTypeOfSuperMethod, String keyName, String fieldName, String defaultValue) {
         String methodName = "get" + StringUtils.capitalize(fieldName);
         String superMethodName = "get" + StringUtils.capitalize(argTypeOfSuperMethod);
         return MethodSpec.methodBuilder(methodName)

--- a/example/src/androidTest/java/com/example/android/kvs/ExamplePrefsTest.java
+++ b/example/src/androidTest/java/com/example/android/kvs/ExamplePrefsTest.java
@@ -79,6 +79,19 @@ public class ExamplePrefsTest {
     }
 
     @Test
+    public void floatWorks(){
+        assertThat(prefs.hasProgress()).isFalse();
+        assertThat(prefs.getProgress(-1.0F)).isEqualTo(-1.0F);
+
+        prefs.putProgress(40.0F);
+        assertThat(prefs.hasProgress()).isTrue();
+        assertThat(prefs.getProgress()).isEqualTo(40.0F);
+
+        prefs.removeProgress();
+        assertThat(prefs.hasProgress()).isFalse();
+    }
+
+    @Test
     public void booleanWorks() {
         assertThat(prefs.hasGuestFlag()).isFalse();
         assertThat(prefs.getGuestFlag(true)).isTrue();

--- a/example/src/main/java/com/example/android/kvs/ExamplePrefsSchema.java
+++ b/example/src/main/java/com/example/android/kvs/ExamplePrefsSchema.java
@@ -15,6 +15,8 @@ public abstract class ExamplePrefsSchema {
     int userAge;
     @Key("guest_flag")
     boolean guestFlag;
+    @Key("progress")
+    float progress;
     @Key("search_history")
     Set<String> searchHistory;
 }


### PR DESCRIPTION
If schema has float field, get error below:
```
error: incompatible types: possible lossy conversion from double to float
Note: Some messages have been simplified; recompile with -Xdiags:verbose to get full output
```

Generated code is below:
```Java
  public float getProgress() {
    return getFloat("progress", 0.0);
  }
```

This happens to pass default value by Object on SchemaWriter.
So I change to pass default value by String.