### PR TITLE
Use bintray as a repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ gradle.properties
 *.swp
 .DS_Store
 build
+
+.env

--- a/README.md
+++ b/README.md
@@ -84,22 +84,11 @@ root@android:/data/data/com.example.android.kvs/shared_prefs # cat example.xml
 
 ### Installation
 
-This library is distributed by [JitPack](https://jitpack.io/).
-
-Add the JitPack repository and dependencies to your build.gradle.
+Add dependencies to your build.gradle.
 
 ```groovy
-allprojects {
-    repositories {
-        ...
-        maven { url "https://jitpack.io" }
-    }
-}
-
-apply plugin: 'com.neenbedankt.android-apt'
-
-apt 'com.github.rejasupotaro.kvs-schema:compiler:3.1.0'
-compile 'com.github.rejasupotaro.kvs-schema:library:3.1.0'
+apt 'com.rejasupotaro:kvs-schema-compiler:4.0.0'
+compile 'com.rejasupotaro:kvs-schema:4.0.0'
 ```
 
 Migration
@@ -151,26 +140,3 @@ You can see what kind of data is saved in your app like below.
  ║ user_id   │ 1            │ String ║
  ╚═══════════╧══════════════╧════════╝
  ```
-
-Development
-----------
-
-**Show version**
-
-```sh
-$ ./gradlew version
-```
-
-**Bump version**
-
-```sh
-$ ./gradlew bumpMajor
-$ ./gradlew bumpMinor
-$ ./gradlew bumpPatch
-```
-
-**Generate README**
-
-```sh
-$ ./gradlew genReadMe
-```

--- a/README.md.template
+++ b/README.md.template
@@ -84,22 +84,11 @@ root@android:/data/data/com.example.android.kvs/shared_prefs # cat example.xml
 
 ### Installation
 
-This library is distributed by [JitPack](https://jitpack.io/).
-
-Add the JitPack repository and dependencies to your build.gradle.
+Add dependencies to your build.gradle.
 
 ```groovy
-allprojects {
-    repositories {
-        ...
-        maven { url "https://jitpack.io" }
-    }
-}
-
-apply plugin: 'com.neenbedankt.android-apt'
-
-apt 'com.github.rejasupotaro.kvs-schema:compiler:%%version%%'
-compile 'com.github.rejasupotaro.kvs-schema:library:%%version%%'
+apt 'com.rejasupotaro:kvs-schema-compiler:%%version%%'
+compile 'com.rejasupotaro:kvs-schema:%%version%%'
 ```
 
 Migration
@@ -151,26 +140,3 @@ You can see what kind of data is saved in your app like below.
  ║ user_id   │ 1            │ String ║
  ╚═══════════╧══════════════╧════════╝
  ```
-
-Development
-----------
-
-**Show version**
-
-```sh
-$ ./gradlew version
-```
-
-**Bump version**
-
-```sh
-$ ./gradlew bumpMajor
-$ ./gradlew bumpMinor
-$ ./gradlew bumpPatch
-```
-
-**Generate README**
-
-```sh
-$ ./gradlew genReadMe
-```

--- a/Rakefile
+++ b/Rakefile
@@ -1,28 +1,34 @@
 require 'dotenv/tasks'
 
+desc "Show current version"
 task :version do
   sh "./gradlew version"
 end
 
+desc "Bump major version"
 task :bump_major do
   sh "./gradlew bumpMajor"
   sh "./gradlew genReadMe"
 end
 
+desc "Bump minor version"
 task :bump_minor do
   sh "./gradlew bumpMinor"
   sh "./gradlew genReadMe"
 end
 
+desc "Bump patch version"
 task :bump_patch do
   sh "./gradlew bumpPatch"
   sh "./gradlew genReadMe"
 end
 
+desc "Rebuild this project"
 task :build do
   sh "./gradlew clean build"
 end
 
+desc "Upload this library to bintray"
 task upload: [:build, :dotenv] do
   sh "./gradlew library:bintrayUpload -PbintrayUser=#{ENV["BINTRAY_USERNAME"]} -PbintrayKey=#{ENV["BINTRAY_API_KEY"]} -PdryRun=false"
   sh "./gradlew compiler:bintrayUpload -PbintrayUser=#{ENV["BINTRAY_USERNAME"]} -PbintrayKey=#{ENV["BINTRAY_API_KEY"]} -PdryRun=false"

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,29 @@
+require 'dotenv/tasks'
+
+task :version do
+  sh "./gradlew version"
+end
+
+task :bump_major do
+  sh "./gradlew bumpMajor"
+  sh "./gradlew genReadMe"
+end
+
+task :bump_minor do
+  sh "./gradlew bumpMinor"
+  sh "./gradlew genReadMe"
+end
+
+task :bump_patch do
+  sh "./gradlew bumpPatch"
+  sh "./gradlew genReadMe"
+end
+
+task :build do
+  sh "./gradlew clean build"
+end
+
+task upload: [:build, :dotenv] do
+  sh "./gradlew library:bintrayUpload -PbintrayUser=#{ENV["BINTRAY_USERNAME"]} -PbintrayKey=#{ENV["BINTRAY_API_KEY"]} -PdryRun=false"
+  sh "./gradlew compiler:bintrayUpload -PbintrayUser=#{ENV["BINTRAY_USERNAME"]} -PbintrayKey=#{ENV["BINTRAY_API_KEY"]} -PdryRun=false"
+end

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:1.5.0'
         classpath 'com.neenbedankt.gradle.plugins:android-apt:1.4'
-        classpath 'com.github.dcendents:android-maven-gradle-plugin:1.3'
+        classpath 'com.novoda:bintray-release:0.3.4'
     }
 }
 

--- a/compiler/build.gradle
+++ b/compiler/build.gradle
@@ -1,5 +1,5 @@
 apply plugin: 'java'
-apply plugin: 'com.github.dcendents.android-maven'
+apply plugin: 'bintray-release'
 
 targetCompatibility = JavaVersion.VERSION_1_8
 sourceCompatibility = JavaVersion.VERSION_1_8
@@ -24,4 +24,14 @@ sourceSets {
             srcDirs = ['src/main/java', '../library/src/main/java']
         }
     }
+}
+
+publish {
+    userOrg = 'rejasupotaro'
+    groupId = 'com.rejasupotaro'
+    artifactId = 'kvs-schema-compiler'
+    publishVersion = VERSION
+    desc = 'Immutable code generation to store key-value data for Android'
+    website = 'https://github.com/rejasupotaro/kvs-schema'
+    licences = ['MIT']
 }

--- a/gradle/version/version.properties
+++ b/gradle/version/version.properties
@@ -1,4 +1,4 @@
-#Fri, 04 Mar 2016 18:18:40 +0900
-major=3
-minor=1
+#Sun, 17 Apr 2016 15:30:55 +0900
+major=4
+minor=0
 patch=0

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -1,7 +1,6 @@
 apply plugin: 'com.android.library'
 apply plugin: 'android-apt'
-apply plugin: 'com.github.dcendents.android-maven'
-group = 'com.github.rejasupotaro'
+apply plugin: 'bintray-release'
 
 android {
     compileSdkVersion 21
@@ -31,4 +30,14 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile 'com.jakewharton.fliptables:fliptables:1.0.2'
+}
+
+publish {
+    userOrg = 'rejasupotaro'
+    groupId = 'com.rejasupotaro'
+    artifactId = 'kvs-schema'
+    publishVersion = VERSION
+    desc = 'Immutable code generation to store key-value data for Android'
+    website = 'https://github.com/rejasupotaro/kvs-schema'
+    licences = ['MIT']
 }


### PR DESCRIPTION
# Overview

As it was mentioned in [here](https://github.com/rejasupotaro/kvs-schema/pull/15#issuecomment-208706025), I started using bintray again.
By this change, artifact id was changed.

```groovy
// before
apt 'com.github.rejasupotaro.kvs-schema:compiler:4.0.0'
compile 'com.github.rejasupotaro.kvs-schema:library:4.0.0'

// after
apt 'com.rejasupotaro:kvs-schema-compiler:4.0.0'
compile 'com.rejasupotaro:kvs-schema:4.0.0'
```

I also added some tasks to upload this library to bintray.

```
$ rake -T
rake build       # Rebuild this project
rake bump_major  # Bump major version
rake bump_minor  # Bump minor version
rake bump_patch  # Bump patch version
rake dotenv      # Load environment settings from .env
rake upload      # Upload this library to bintray
rake version     # Show current version
```

To upload this library, `.env` is required.

```
BINTRAY_USERNAME="xxxxx"
BINTRAY_API_KEY="xxxxx"
```

# Related links

- novoda/bintray-release: A helper for releasing from gradle up to bintray https://github.com/novoda/bintray-release
- v2.0.0 by rejasupotaro · Pull Request #9 · rejasupotaro/kvs-schema https://github.com/rejasupotaro/kvs-schema/pull/9/commits/685915dd4a679ed932619d24ed2e4d57e71de9e2
- kvs-schema https://bintray.com/rejasupotaro/maven/kvs-schema/view
- kvs-schema-compiler https://bintray.com/rejasupotaro/maven/kvs-schema-compiler/view