### PR TITLE
Support serializer

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,87 +2,109 @@ KVS Schema
 ==========
 
 KVS Schema is a library to manage key-value data for Android.
-This library generates methods from annotated fields in compile time.
-For example, when a schema class has `@Key("user_id") String userId` like below,
-
-```java
-@Table(name = "example")
-public class ExamplePrefsSchema {
-    @Key("user_id") String userId;
-}
-```
-
-KVS Schema generates accessor methods below.
-
-- `ExamplePrefs#getUserId`
-- `ExamplePrefs#putUserId`
-- `ExamplePrefs#removeUserId`
-- `ExamplePrefs#hasUserId`
-
-Values are stored on SharedPreferences through generated class.
+This library generates accessor methods of SharedPreferences from schema class in compile time.
 
 How to use
-----------
+--------
 
 ### Create Schema
 
-Class name should be `*Schema`.
+Let's say you will store user id, You have to create a schema class like below.
 
 ```java
 @Table(name = "example")
 public class ExamplePrefsSchema {
     @Key("user_id") int userId;
-    @Key("user_name") String userName;
 }
 ```
 
-### Read and Write
+Class name should be `*Schema`.
 
-`put*`, `get*`, `has*` and `remove*` methods will be generated in compile time.
+KVS Schema generates `ExamplePrefs` from `ExamplePrefsSchema`. You can use generated accessors below.
 
 ```java
 ExamplePrefs prefs = ExamplePrefs.get(context);
-prefs.putUserId(123);
-prefs.putUserName("Jack");
-prefs.hasUserName(); // => true
-prefs.getUserName(); // => Jack
-prefs.removeUserName();
-prefs.hasUserName(); // => false
+prefs.putUserId(userId);
+prefs.putUserId(userId, defaultValue);
+prefs.getUserId();
+prefs.hasUserId();
+prefs.removeUserId();
 ```
 
-Initialize method (ExamplePrefs.get) is also generated. It provides singleton instance of Prefs.
-You can change initialize method of Prefs by specifying builder class.
+KVS supports `boolean` `String` `float` `int` `long` `String` `set`.
+
+### Default Values
+
+You can specify default values for the case of that a given key doesn't be contained in a SharedPreferences.
 
 ```java
+prefs.getUserId(defaultValue);
+```
+
+You can also specify default values through a schema class. KVS Schema can read right values that become a constant in compile time.
+
+```java
+@Table(name = "example")
+public abstract class ExamplePrefsSchema {
+    @Key(name = "user_id") final int userId = -1;
+}
+```
+
+Using the mechanism, you don't have to specify default values when you set right values that is *a final field initialized to a compile time constant*.
+
+### Serializer
+
+Sometimes you want to put model classes into SharedPreferences. For that cases, KVS Schema can store data using serializer class.
+
+```java
+// Schema class
+@Table(name = "example")
+public abstract class ExamplePrefsSchema {
+    @Key(name = "user", serializer = UserPrefsSerializer.class) String user;
+}
+
+// Serializer class
+public class UserSerializer implements PrefsSerializer<User, String> {
+    @Override public String serialize(User src) { return GSON.toJson(src); }
+    @Override public User deserialize(String src) { return GSON.fromJson(src, User.class); }
+}
+
+// Usage
+prefs.putUser(user);
+```
+
+### Builder
+
+You can specify builder class to use custom SharedPreferences.
+
+```java
+// Schema class
 @Table(name = "example", builder = ExamplePrefsBuilder.class)
+public abstract class ExamplePrefsSchema {
+    @Key(name = "user_id") int userId;
+}
+
+// Builder class
+public class ExamplePrefsBuilder implements PrefsBuilder<ExamplePrefs>　{
+    @Override
+    public ExamplePrefs build(Context context) {
+        ...
+        return new ExamplePrefs(...); // You can pass your SharedPreferences here
+    }
+}
 ```
 
-See: https://github.com/rejasupotaro/kvs-schema/pull/12
+### Using from Kotlin
 
-### Supported types
+KVS Schema generates `set*` method as an alias of `put*` to utilize property syntax of Kotlin. So you can read/write values like below when you use Kotlin.
 
-kvs-schema supports these types for now.
-
-- boolean
-- String
-- float
-- int
-- long
-- String set
-
-### Saved XML
-
-Table's name becomes SharedPreferences' name.
-
-```xml
-root@android:/data/data/com.example.android.kvs/shared_prefs # cat example.xml
-<?xml version='1.0' encoding='utf-8' standalone='yes' ?>
-<map>
-<string name="user_id">123</string>
-</map>
+```java
+prefs.userId = "Kotlin"
+prefs.userId // => Kotlin
 ```
 
-### Installation
+Installation
+--------
 
 Add dependencies to your build.gradle.
 
@@ -92,9 +114,9 @@ compile 'com.rejasupotaro:kvs-schema:4.1.0'
 ```
 
 Migration
-----------
+--------
 
-Even if you have already used SharedPreferences directly, migration is easy. KVS Schema simply maps the structure of SharedPreferences.
+Even if you have already used SharedPreferences directly in your existing app, migration is easy. KVS Schema simply maps the structure of SharedPreferences.
 
 For example, if you are using default SharedPreferences like below,
 
@@ -102,11 +124,11 @@ For example, if you are using default SharedPreferences like below,
 prefs = PreferenceManager.getDefaultSharedPreferences(this);
 Editor editor = prefs.edit();
 editor.putString("user_id", "1");
-editor.putString("user_name", "rejasupotaro");
+editor.putString("user_name", "Smith");
 editor.apply();
 ```
 
-your data is saved on `path/to/app/shared_prefs/package_name_preferences.xml`. The schema becomes below.
+your data is saved on `path/to/app/shared_prefs/package_name_preferences.xml`. The schema class becomes like below.
 
 ```java
 @Table("package_name_preferences")
@@ -116,9 +138,9 @@ public abstract class ExamplePrefsSchema {
 }
 ```
 
-See concrete example: https://github.com/konifar/droidkaigi2016/pull/311
+See a concrete example: https://github.com/konifar/droidkaigi2016/pull/311
 
-In addition, SharedPreferencesInfo may help you to migrate existing app. You can get existing SharedPreferences through `SharedPreferencesInfo.getAllPrefsAsTable`.
+In addition, SharedPreferencesInfo may help you to migrate from existing apps. You can get existing SharedPreferences through `SharedPreferencesInfo.getAllPrefsAsTable`.
 
 ```java
 List<SharedPreferencesTable> tables = SharedPreferencesInfo.getAll(this);
@@ -135,8 +157,8 @@ You can see what kind of data is saved in your app like below.
  ╔═══════════╤══════════════╤════════╗
  ║ Key       │ Value        │ Type   ║
  ╠═══════════╪══════════════╪════════╣
- ║ user_name │ rejasupotaro │ String ║
+ ║ user_name │ Smith        │ String ║
  ╟───────────┼──────────────┼────────╢
  ║ user_id   │ 1            │ String ║
  ╚═══════════╧══════════════╧════════╝
- ```
+```

--- a/README.md.template
+++ b/README.md.template
@@ -2,87 +2,109 @@ KVS Schema
 ==========
 
 KVS Schema is a library to manage key-value data for Android.
-This library generates methods from annotated fields in compile time.
-For example, when a schema class has `@Key("user_id") String userId` like below,
-
-```java
-@Table(name = "example")
-public class ExamplePrefsSchema {
-    @Key("user_id") String userId;
-}
-```
-
-KVS Schema generates accessor methods below.
-
-- `ExamplePrefs#getUserId`
-- `ExamplePrefs#putUserId`
-- `ExamplePrefs#removeUserId`
-- `ExamplePrefs#hasUserId`
-
-Values are stored on SharedPreferences through generated class.
+This library generates accessor methods of SharedPreferences from schema class in compile time.
 
 How to use
-----------
+--------
 
 ### Create Schema
 
-Class name should be `*Schema`.
+Let's say you will store user id, You have to create a schema class like below.
 
 ```java
 @Table(name = "example")
 public class ExamplePrefsSchema {
     @Key("user_id") int userId;
-    @Key("user_name") String userName;
 }
 ```
 
-### Read and Write
+Class name should be `*Schema`.
 
-`put*`, `get*`, `has*` and `remove*` methods will be generated in compile time.
+KVS Schema generates `ExamplePrefs` from `ExamplePrefsSchema`. You can use generated accessors below.
 
 ```java
 ExamplePrefs prefs = ExamplePrefs.get(context);
-prefs.putUserId(123);
-prefs.putUserName("Jack");
-prefs.hasUserName(); // => true
-prefs.getUserName(); // => Jack
-prefs.removeUserName();
-prefs.hasUserName(); // => false
+prefs.putUserId(userId);
+prefs.putUserId(userId, defaultValue);
+prefs.getUserId();
+prefs.hasUserId();
+prefs.removeUserId();
 ```
 
-Initialize method (ExamplePrefs.get) is also generated. It provides singleton instance of Prefs.
-You can change initialize method of Prefs by specifying builder class.
+KVS supports `boolean` `String` `float` `int` `long` `String` `set`.
+
+### Default Values
+
+You can specify default values for the case of that a given key doesn't be contained in a SharedPreferences.
 
 ```java
+prefs.getUserId(defaultValue);
+```
+
+You can also specify default values through a schema class. KVS Schema can read right values that become a constant in compile time.
+
+```java
+@Table(name = "example")
+public abstract class ExamplePrefsSchema {
+    @Key(name = "user_id") final int userId = -1;
+}
+```
+
+Using the mechanism, you don't have to specify default values when you set right values that is *a final field initialized to a compile time constant*.
+
+### Serializer
+
+Sometimes you want to put model classes into SharedPreferences. For that cases, KVS Schema can store data using serializer class.
+
+```java
+// Schema class
+@Table(name = "example")
+public abstract class ExamplePrefsSchema {
+    @Key(name = "user", serializer = UserPrefsSerializer.class) String user;
+}
+
+// Serializer class
+public class UserSerializer implements PrefsSerializer<User, String> {
+    @Override public String serialize(User src) { return GSON.toJson(src); }
+    @Override public User deserialize(String src) { return GSON.fromJson(src, User.class); }
+}
+
+// Usage
+prefs.putUser(user);
+```
+
+### Builder
+
+You can specify builder class to use custom SharedPreferences.
+
+```java
+// Schema class
 @Table(name = "example", builder = ExamplePrefsBuilder.class)
+public abstract class ExamplePrefsSchema {
+    @Key(name = "user_id") int userId;
+}
+
+// Builder class
+public class ExamplePrefsBuilder implements PrefsBuilder<ExamplePrefs>　{
+    @Override
+    public ExamplePrefs build(Context context) {
+        ...
+        return new ExamplePrefs(...); // You can pass your SharedPreferences here
+    }
+}
 ```
 
-See: https://github.com/rejasupotaro/kvs-schema/pull/12
+### Using from Kotlin
 
-### Supported types
+KVS Schema generates `set*` method as an alias of `put*` to utilize property syntax of Kotlin. So you can read/write values like below when you use Kotlin.
 
-kvs-schema supports these types for now.
-
-- boolean
-- String
-- float
-- int
-- long
-- String set
-
-### Saved XML
-
-Table's name becomes SharedPreferences' name.
-
-```xml
-root@android:/data/data/com.example.android.kvs/shared_prefs # cat example.xml
-<?xml version='1.0' encoding='utf-8' standalone='yes' ?>
-<map>
-<string name="user_id">123</string>
-</map>
+```java
+prefs.userId = "Kotlin"
+prefs.userId // => Kotlin
 ```
 
-### Installation
+Installation
+--------
 
 Add dependencies to your build.gradle.
 
@@ -92,9 +114,9 @@ compile 'com.rejasupotaro:kvs-schema:%%version%%'
 ```
 
 Migration
-----------
+--------
 
-Even if you have already used SharedPreferences directly, migration is easy. KVS Schema simply maps the structure of SharedPreferences.
+Even if you have already used SharedPreferences directly in your existing app, migration is easy. KVS Schema simply maps the structure of SharedPreferences.
 
 For example, if you are using default SharedPreferences like below,
 
@@ -102,11 +124,11 @@ For example, if you are using default SharedPreferences like below,
 prefs = PreferenceManager.getDefaultSharedPreferences(this);
 Editor editor = prefs.edit();
 editor.putString("user_id", "1");
-editor.putString("user_name", "rejasupotaro");
+editor.putString("user_name", "Smith");
 editor.apply();
 ```
 
-your data is saved on `path/to/app/shared_prefs/package_name_preferences.xml`. The schema becomes below.
+your data is saved on `path/to/app/shared_prefs/package_name_preferences.xml`. The schema class becomes like below.
 
 ```java
 @Table("package_name_preferences")
@@ -116,9 +138,9 @@ public abstract class ExamplePrefsSchema {
 }
 ```
 
-See concrete example: https://github.com/konifar/droidkaigi2016/pull/311
+See a concrete example: https://github.com/konifar/droidkaigi2016/pull/311
 
-In addition, SharedPreferencesInfo may help you to migrate existing app. You can get existing SharedPreferences through `SharedPreferencesInfo.getAllPrefsAsTable`.
+In addition, SharedPreferencesInfo may help you to migrate from existing apps. You can get existing SharedPreferences through `SharedPreferencesInfo.getAllPrefsAsTable`.
 
 ```java
 List<SharedPreferencesTable> tables = SharedPreferencesInfo.getAll(this);
@@ -135,8 +157,8 @@ You can see what kind of data is saved in your app like below.
  ╔═══════════╤══════════════╤════════╗
  ║ Key       │ Value        │ Type   ║
  ╠═══════════╪══════════════╪════════╣
- ║ user_name │ rejasupotaro │ String ║
+ ║ user_name │ Smith        │ String ║
  ╟───────────┼──────────────┼────────╢
  ║ user_id   │ 1            │ String ║
  ╚═══════════╧══════════════╧════════╝
- ```
+```

--- a/compiler/src/main/java/com/rejasupotaro/android/kvs/internal/Field.java
+++ b/compiler/src/main/java/com/rejasupotaro/android/kvs/internal/Field.java
@@ -1,14 +1,27 @@
 package com.rejasupotaro.android.kvs.internal;
 
 import com.rejasupotaro.android.kvs.annotations.Key;
+import com.rejasupotaro.android.kvs.serializers.DefaultSerializer;
+import com.rejasupotaro.android.kvs.serializers.Serializer;
 import com.squareup.javapoet.TypeName;
 
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.List;
+
 import javax.lang.model.element.Element;
+import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.VariableElement;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.MirroredTypeException;
+import javax.lang.model.type.TypeKind;
+import javax.lang.model.type.TypeMirror;
 
 public class Field {
     private String prefKeyName;
-    private TypeName type;
+    private TypeName serializerType;
+    private TypeName serializeType;
+    private TypeName fieldType;
     private String name;
     private Object value;
 
@@ -16,8 +29,20 @@ public class Field {
         return prefKeyName;
     }
 
-    public TypeName getType() {
-        return type;
+    public boolean hasSerializer() {
+        return !TypeName.get(DefaultSerializer.class).equals(serializerType);
+    }
+
+    public TypeName getSerializerType() {
+        return serializerType;
+    }
+
+    public TypeName getSerializeType() {
+        return serializeType;
+    }
+
+    public TypeName getFieldType() {
+        return fieldType;
     }
 
     public String getName() {
@@ -28,11 +53,84 @@ public class Field {
         return value;
     }
 
-    public Field(Element element, Key prefKeyName) {
-        this.prefKeyName = prefKeyName.value();
+    public Field(Element element, Key key) {
+        this.prefKeyName = key.name();
+
+        try {
+            Class clazz = key.serializer();
+            serializerType = TypeName.get(clazz);
+            serializeType = detectSerializeTypeNameByClass(clazz);
+        } catch (MirroredTypeException mte) {
+            DeclaredType classTypeMirror = (DeclaredType) mte.getTypeMirror();
+            TypeElement classTypeElement = (TypeElement) classTypeMirror.asElement();
+            serializerType = TypeName.get(classTypeMirror);
+            serializeType = detectSerializeTypeByTypeElement(classTypeElement);
+        }
+
         VariableElement variable = (VariableElement) element;
-        this.type = TypeName.get(element.asType());
+        this.fieldType = TypeName.get(element.asType());
         this.name = element.getSimpleName().toString();
         this.value = variable.getConstantValue();
+    }
+
+    private TypeName detectSerializeTypeNameByClass(Class clazz) {
+        TypeName serializeType = TypeName.get(getSerializerGenericsTypesByClass(clazz)[0]);
+        try {
+            serializeType = serializeType.unbox();
+        } catch (UnsupportedOperationException ignore) {
+        }
+        return serializeType;
+    }
+
+    private TypeName detectSerializeTypeByTypeElement(TypeElement element) {
+        TypeName serializeType = TypeName.get(getSerializerGenericsTypesByTypeElement(element).get(0));
+        try {
+            serializeType = serializeType.unbox();
+        } catch (UnsupportedOperationException ignore) {
+        }
+        return serializeType;
+    }
+
+    private Type[] getSerializerGenericsTypesByClass(Class clazz) {
+        Type type = Serializer.class;
+        Class targetClass = clazz;
+        while (targetClass != null) {
+            for (Type in : targetClass.getGenericInterfaces()) {
+                if (in instanceof ParameterizedType &&
+                        type.equals(((ParameterizedType) in).getRawType())) {
+                    return ((ParameterizedType) in).getActualTypeArguments();
+                }
+            }
+            Type superClazz = targetClass.getGenericSuperclass();
+            if (superClazz instanceof ParameterizedType &&
+                    type.equals(((ParameterizedType) superClazz).getRawType())) {
+                return ((ParameterizedType) superClazz).getActualTypeArguments();
+            }
+            targetClass = targetClass.getSuperclass();
+        }
+        throw new UnsupportedOperationException("Not found serializer type: " + clazz.getName());
+    }
+
+    private List<? extends TypeMirror> getSerializerGenericsTypesByTypeElement(TypeElement element) {
+        TypeElement targetType = element;
+        while (targetType != null) {
+            if (!targetType.getInterfaces().isEmpty()) {
+                for (TypeMirror in : targetType.getInterfaces()) {
+                    DeclaredType inType = (DeclaredType) in;
+                    if (inType.asElement().getSimpleName().toString()
+                            .equals(Serializer.class.getSimpleName())) {
+                        return inType.getTypeArguments();
+                    }
+                }
+            }
+
+            TypeMirror superClassType = targetType.getSuperclass();
+            if (superClassType.getKind().equals(TypeKind.DECLARED)) {
+                targetType = (TypeElement) ((DeclaredType) superClassType).asElement();
+            } else {
+                break;
+            }
+        }
+        throw new UnsupportedOperationException("Not found serializer type: " + element.toString());
     }
 }

--- a/compiler/src/main/java/com/rejasupotaro/android/kvs/internal/Field.java
+++ b/compiler/src/main/java/com/rejasupotaro/android/kvs/internal/Field.java
@@ -1,8 +1,8 @@
 package com.rejasupotaro.android.kvs.internal;
 
 import com.rejasupotaro.android.kvs.annotations.Key;
-import com.rejasupotaro.android.kvs.serializers.DefaultSerializer;
-import com.rejasupotaro.android.kvs.serializers.Serializer;
+import com.rejasupotaro.android.kvs.serializers.DefaultPrefsSerializer;
+import com.rejasupotaro.android.kvs.serializers.PrefsSerializer;
 import com.squareup.javapoet.TypeName;
 
 import java.lang.reflect.ParameterizedType;
@@ -30,7 +30,7 @@ public class Field {
     }
 
     public boolean hasSerializer() {
-        return !TypeName.get(DefaultSerializer.class).equals(serializerType);
+        return !TypeName.get(DefaultPrefsSerializer.class).equals(serializerType);
     }
 
     public TypeName getSerializerType() {
@@ -92,7 +92,7 @@ public class Field {
     }
 
     private Type[] getSerializerGenericsTypesByClass(Class clazz) {
-        Type type = Serializer.class;
+        Type type = PrefsSerializer.class;
         Class targetClass = clazz;
         while (targetClass != null) {
             for (Type in : targetClass.getGenericInterfaces()) {
@@ -118,7 +118,7 @@ public class Field {
                 for (TypeMirror in : targetType.getInterfaces()) {
                     DeclaredType inType = (DeclaredType) in;
                     if (inType.asElement().getSimpleName().toString()
-                            .equals(Serializer.class.getSimpleName())) {
+                            .equals(PrefsSerializer.class.getSimpleName())) {
                         return inType.getTypeArguments();
                     }
                 }

--- a/compiler/src/main/java/com/rejasupotaro/android/kvs/internal/Field.java
+++ b/compiler/src/main/java/com/rejasupotaro/android/kvs/internal/Field.java
@@ -5,17 +5,11 @@ import com.rejasupotaro.android.kvs.serializers.DefaultPrefsSerializer;
 import com.rejasupotaro.android.kvs.serializers.PrefsSerializer;
 import com.squareup.javapoet.TypeName;
 
-import java.lang.reflect.ParameterizedType;
-import java.lang.reflect.Type;
-import java.util.List;
-
 import javax.lang.model.element.Element;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.MirroredTypeException;
-import javax.lang.model.type.TypeKind;
-import javax.lang.model.type.TypeMirror;
 
 public class Field {
     private String prefKeyName;
@@ -74,63 +68,12 @@ public class Field {
     }
 
     private TypeName detectSerializeTypeNameByClass(Class clazz) {
-        TypeName serializeType = TypeName.get(getSerializerGenericsTypesByClass(clazz)[0]);
-        try {
-            serializeType = serializeType.unbox();
-        } catch (UnsupportedOperationException ignore) {
-        }
-        return serializeType;
+        TypeName serializeType = TypeName.get(TypeUtils.getGenericsTypesByClass(clazz, PrefsSerializer.class)[0]);
+        return TypeUtils.unbox(serializeType);
     }
 
     private TypeName detectSerializeTypeByTypeElement(TypeElement element) {
-        TypeName serializeType = TypeName.get(getSerializerGenericsTypesByTypeElement(element).get(0));
-        try {
-            serializeType = serializeType.unbox();
-        } catch (UnsupportedOperationException ignore) {
-        }
-        return serializeType;
-    }
-
-    private Type[] getSerializerGenericsTypesByClass(Class clazz) {
-        Type type = PrefsSerializer.class;
-        Class targetClass = clazz;
-        while (targetClass != null) {
-            for (Type in : targetClass.getGenericInterfaces()) {
-                if (in instanceof ParameterizedType &&
-                        type.equals(((ParameterizedType) in).getRawType())) {
-                    return ((ParameterizedType) in).getActualTypeArguments();
-                }
-            }
-            Type superClazz = targetClass.getGenericSuperclass();
-            if (superClazz instanceof ParameterizedType &&
-                    type.equals(((ParameterizedType) superClazz).getRawType())) {
-                return ((ParameterizedType) superClazz).getActualTypeArguments();
-            }
-            targetClass = targetClass.getSuperclass();
-        }
-        throw new UnsupportedOperationException("Not found serializer type: " + clazz.getName());
-    }
-
-    private List<? extends TypeMirror> getSerializerGenericsTypesByTypeElement(TypeElement element) {
-        TypeElement targetType = element;
-        while (targetType != null) {
-            if (!targetType.getInterfaces().isEmpty()) {
-                for (TypeMirror in : targetType.getInterfaces()) {
-                    DeclaredType inType = (DeclaredType) in;
-                    if (inType.asElement().getSimpleName().toString()
-                            .equals(PrefsSerializer.class.getSimpleName())) {
-                        return inType.getTypeArguments();
-                    }
-                }
-            }
-
-            TypeMirror superClassType = targetType.getSuperclass();
-            if (superClassType.getKind().equals(TypeKind.DECLARED)) {
-                targetType = (TypeElement) ((DeclaredType) superClassType).asElement();
-            } else {
-                break;
-            }
-        }
-        throw new UnsupportedOperationException("Not found serializer type: " + element.toString());
+        TypeName serializeType = TypeName.get(TypeUtils.getGenericsTypesByTypeElement(element, PrefsSerializer.class).get(0));
+        return TypeUtils.unbox(serializeType);
     }
 }

--- a/compiler/src/main/java/com/rejasupotaro/android/kvs/internal/TypeUtils.java
+++ b/compiler/src/main/java/com/rejasupotaro/android/kvs/internal/TypeUtils.java
@@ -1,0 +1,67 @@
+package com.rejasupotaro.android.kvs.internal;
+
+import com.squareup.javapoet.TypeName;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.List;
+
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.TypeKind;
+import javax.lang.model.type.TypeMirror;
+
+public final class TypeUtils {
+    private TypeUtils() {
+    }
+
+    public static TypeName unbox(TypeName typeName) {
+        try {
+            return typeName.unbox();
+        } catch (UnsupportedOperationException ignore) {
+            return typeName;
+        }
+    }
+
+    public static Type[] getGenericsTypesByClass(Class clazz, Type type) {
+        Class targetClass = clazz;
+        while (targetClass != null) {
+            for (Type in : targetClass.getGenericInterfaces()) {
+                if (in instanceof ParameterizedType &&
+                        type.equals(((ParameterizedType) in).getRawType())) {
+                    return ((ParameterizedType) in).getActualTypeArguments();
+                }
+            }
+            Type superClazz = targetClass.getGenericSuperclass();
+            if (superClazz instanceof ParameterizedType &&
+                    type.equals(((ParameterizedType) superClazz).getRawType())) {
+                return ((ParameterizedType) superClazz).getActualTypeArguments();
+            }
+            targetClass = targetClass.getSuperclass();
+        }
+        throw new UnsupportedOperationException("Not found serializer type: " + clazz.getName());
+    }
+
+    public static List<? extends TypeMirror> getGenericsTypesByTypeElement(TypeElement element, Class clazz) {
+        TypeElement targetType = element;
+        while (targetType != null) {
+            if (!targetType.getInterfaces().isEmpty()) {
+                for (TypeMirror in : targetType.getInterfaces()) {
+                    DeclaredType inType = (DeclaredType) in;
+                    if (inType.asElement().getSimpleName().toString()
+                            .equals(clazz.getSimpleName())) {
+                        return inType.getTypeArguments();
+                    }
+                }
+            }
+
+            TypeMirror superClassType = targetType.getSuperclass();
+            if (superClassType.getKind().equals(TypeKind.DECLARED)) {
+                targetType = (TypeElement) ((DeclaredType) superClassType).asElement();
+            } else {
+                break;
+            }
+        }
+        throw new UnsupportedOperationException("Not found serializer type: " + element.toString());
+    }
+}

--- a/compiler/src/test/java/com/rejasupotaro/android/kvs/internal/StringUtilsTest.java
+++ b/compiler/src/test/java/com/rejasupotaro/android/kvs/internal/StringUtilsTest.java
@@ -6,12 +6,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class StringUtilsTest {
     @Test
-    public void testCapitalize() {
+    public void capitalize() {
         assertThat(StringUtils.capitalize("username")).isEqualTo("Username");
     }
 
     @Test
-    public void testIsEmpty() {
+    public void isEmpty() {
         assertThat(StringUtils.isEmpty(null)).isTrue();
         assertThat(StringUtils.isEmpty("")).isTrue();
         assertThat(StringUtils.isEmpty("foo")).isFalse();

--- a/compiler/src/test/java/com/rejasupotaro/android/kvs/internal/TypeUtilsTest.java
+++ b/compiler/src/test/java/com/rejasupotaro/android/kvs/internal/TypeUtilsTest.java
@@ -1,0 +1,24 @@
+package com.rejasupotaro.android.kvs.internal;
+
+import org.junit.Test;
+
+import java.lang.reflect.Type;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TypeUtilsTest {
+    @Test
+    public void getGenericsTypesByClass() {
+        Class<? extends Serializer> clazz = SerializerImpl.class;
+        Type[] types = TypeUtils.getGenericsTypesByClass(clazz, Serializer.class);
+        assertThat(types.length).isEqualTo(2);
+        assertThat(types[0].getTypeName()).isEqualTo("java.lang.String");
+        assertThat(types[1].getTypeName()).isEqualTo("java.lang.Integer");
+    }
+
+    private interface Serializer<A, B> {
+    }
+
+    private class SerializerImpl implements Serializer<String, Integer> {
+    }
+}

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -48,6 +48,8 @@ dependencies {
     apt 'com.jakewharton:butterknife:7.0.1-compiler'
     compile 'com.jakewharton:butterknife:7.0.1'
 
+    compile 'com.google.code.gson:gson:2.6.2'
+
     androidTestCompile 'com.android.support.test:testing-support-lib:0.1'
     androidTestCompile 'org.mockito:mockito-core:1.9.5'
     androidTestCompile 'com.google.dexmaker:dexmaker:1.1'

--- a/example/src/androidTest/java/com/example/android/kvs/TestWithDefaultPrefsTest.java
+++ b/example/src/androidTest/java/com/example/android/kvs/TestWithDefaultPrefsTest.java
@@ -15,28 +15,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 @RunWith(AndroidJUnit4.class)
 public class TestWithDefaultPrefsTest {
 
-    private Context context;
     private TestWithDefaultPrefs prefs;
 
     @Before
     public void setup() {
-        this.context = InstrumentationRegistry.getTargetContext();
+        Context context = InstrumentationRegistry.getTargetContext();
         this.prefs = TestWithDefaultPrefs.get(context);
         prefs.clear();
-    }
-
-    @Test
-    public void getSingletonInstance() {
-        {
-            TestWithDefaultPrefs prefs1 = new TestWithDefaultPrefs(context);
-            TestWithDefaultPrefs prefs2 = new TestWithDefaultPrefs(context);
-            assertThat(prefs1).isNotEqualTo(prefs2);
-        }
-        {
-            TestWithDefaultPrefs prefs1 = TestWithDefaultPrefs.get(context);
-            TestWithDefaultPrefs prefs2 = TestWithDefaultPrefs.get(context);
-            assertThat(prefs1).isEqualTo(prefs2);
-        }
     }
 
     @Test

--- a/example/src/androidTest/java/com/example/android/kvs/TestWithSerializerPrefsTest.java
+++ b/example/src/androidTest/java/com/example/android/kvs/TestWithSerializerPrefsTest.java
@@ -1,0 +1,63 @@
+package com.example.android.kvs;
+
+import android.content.Context;
+import android.support.test.InstrumentationRegistry;
+import android.support.test.runner.AndroidJUnit4;
+
+import com.example.android.kvs.models.User;
+import com.example.android.kvs.prefs.schemas.TestWithSerializerPrefs;
+import com.example.android.kvs.prefs.serializer.UserIntSerializer;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(AndroidJUnit4.class)
+public class TestWithSerializerPrefsTest {
+
+    private TestWithSerializerPrefs prefs;
+
+    @Before
+    public void setup() {
+        Context context = InstrumentationRegistry.getTargetContext();
+        this.prefs = TestWithSerializerPrefs.get(context);
+        prefs.clear();
+    }
+
+
+    @Test
+    public void serializeStringTypeWorks() {
+        assertThat(prefs.hasUserString()).isFalse();
+
+        User user = new User(99999999999L, "Smith", 32, true);
+        prefs.putUserString(user);
+        assertThat(prefs.hasUserString()).isTrue();
+        User storedUser = prefs.getUserString();
+        assertThat(storedUser.getId()).isEqualTo(99999999999L);
+        assertThat(storedUser.getName()).isEqualTo("Smith");
+        assertThat(storedUser.getAge()).isEqualTo(32);
+        assertThat(storedUser.isGuest()).isTrue();
+
+        prefs.removeUserString();
+        assertThat(prefs.hasUserString()).isFalse();
+    }
+
+    @Test
+    public void serializeIntTypeWorks() {
+        assertThat(prefs.hasUserInt()).isFalse();
+
+        User user = UserIntSerializer.USERS.get(1);
+        prefs.putUserString(user);
+        assertThat(prefs.hasUserString()).isTrue();
+        User storedUser = prefs.getUserString();
+        assertThat(storedUser.getId()).isEqualTo(2L);
+        assertThat(storedUser.getName()).isEqualTo("John");
+        assertThat(storedUser.getAge()).isEqualTo(28);
+        assertThat(storedUser.isGuest()).isTrue();
+
+        prefs.removeUserString();
+        assertThat(prefs.hasUserString()).isFalse();
+    }
+}

--- a/example/src/main/java/com/example/android/kvs/MainActivity.java
+++ b/example/src/main/java/com/example/android/kvs/MainActivity.java
@@ -7,6 +7,7 @@ import android.view.Menu;
 import android.view.MenuItem;
 import android.widget.TextView;
 
+import com.example.android.kvs.models.User;
 import com.example.android.kvs.prefs.schemas.ExamplePrefs;
 import com.rejasupotaro.android.kvs.SharedPreferencesInfo;
 import com.rejasupotaro.android.kvs.SharedPreferencesTable;
@@ -39,20 +40,22 @@ public class MainActivity extends AppCompatActivity {
     }
 
     private void setupViews() {
+        User user = new User(1, "Smith", 32, true);
+
         ExamplePrefs prefs = ExamplePrefs.get(this);
 
-        prefs.putUserId(1L);
+        prefs.putUserId(user.getId());
         long id = prefs.getUserId();
         userIdTextView.setText("" + id);
 
-        prefs.putGuestFlag(false);
+        prefs.putGuestFlag(user.isGuest());
         boolean isGuest = prefs.getGuestFlag();
         guestFlagTextView.setText("" + isGuest);
 
-        prefs.putUserName("Smith");
+        prefs.putUserName(user.getName());
         userNameTextView.setText(prefs.getUserName());
 
-        prefs.putUserAge(32);
+        prefs.putUserAge(user.getAge());
         long age = prefs.getUserAge();
         userAgeTextView.setText("" + age);
 
@@ -61,8 +64,8 @@ public class MainActivity extends AppCompatActivity {
             add("pork stake");
             add("banana cake");
         }});
-        Set<String> languages = prefs.getSearchHistory();
-        searchHistoryTextView.setText(languages.toString());
+        Set<String> searchHistory = prefs.getSearchHistory();
+        searchHistoryTextView.setText(searchHistory.toString());
 
         List<SharedPreferencesTable> tables = SharedPreferencesInfo.getAll(this);
         for (SharedPreferencesTable table : tables) {

--- a/example/src/main/java/com/example/android/kvs/models/User.java
+++ b/example/src/main/java/com/example/android/kvs/models/User.java
@@ -1,0 +1,31 @@
+package com.example.android.kvs.models;
+
+public class User {
+    private long id;
+    private String name;
+    private int age;
+    private boolean guestFlag;
+
+    public long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public int getAge() {
+        return age;
+    }
+
+    public boolean isGuest() {
+        return guestFlag;
+    }
+
+    public User(long id, String name, int age, boolean guestFlag) {
+        this.id = id;
+        this.name = name;
+        this.age = age;
+        this.guestFlag = guestFlag;
+    }
+}

--- a/example/src/main/java/com/example/android/kvs/prefs/schemas/ExamplePrefsSchema.java
+++ b/example/src/main/java/com/example/android/kvs/prefs/schemas/ExamplePrefsSchema.java
@@ -8,16 +8,16 @@ import java.util.Set;
 
 @Table(name = "example", builder = ExamplePrefsBuilder.class)
 public abstract class ExamplePrefsSchema {
-    @Key("user_id")
+    @Key(name = "user_id")
     long userId;
-    @Key("user_name")
+    @Key(name = "user_name")
     String userName;
-    @Key("user_age")
+    @Key(name = "user_age")
     int userAge;
-    @Key("guest_flag")
+    @Key(name = "guest_flag")
     boolean guestFlag;
-    @Key("progress")
+    @Key(name = "progress")
     float progress;
-    @Key("search_history")
+    @Key(name = "search_history")
     Set<String> searchHistory;
 }

--- a/example/src/main/java/com/example/android/kvs/prefs/schemas/TestPrefsSchema.java
+++ b/example/src/main/java/com/example/android/kvs/prefs/schemas/TestPrefsSchema.java
@@ -7,17 +7,17 @@ import java.util.Set;
 
 @Table(name = "test")
 public abstract class TestPrefsSchema {
-    @Key("long_value")
+    @Key(name = "long_value")
     long longValue;
-    @Key("string_value")
+    @Key(name = "string_value")
     String stringValue;
-    @Key("int_value")
+    @Key(name = "int_value")
     int intValue;
-    @Key("boolean_value")
+    @Key(name = "boolean_value")
     boolean booleanValue;
-    @Key("float_value")
+    @Key(name = "float_value")
     float floatValue;
-    @Key("string_set_value")
+    @Key(name = "string_set_value")
     Set<String> stringSetValue;
 }
 

--- a/example/src/main/java/com/example/android/kvs/prefs/schemas/TestWithDefaultPrefsSchema.java
+++ b/example/src/main/java/com/example/android/kvs/prefs/schemas/TestWithDefaultPrefsSchema.java
@@ -7,17 +7,17 @@ import java.util.Set;
 
 @Table(name = "test_with_default")
 public abstract class TestWithDefaultPrefsSchema {
-    @Key("long_value")
+    @Key(name = "long_value")
     final long longValue = 99999999999L;
-    @Key("string_value")
+    @Key(name = "string_value")
     final String stringValue = "abc";
-    @Key("int_value")
+    @Key(name = "int_value")
     final int intValue = -1;
-    @Key("boolean_value")
+    @Key(name = "boolean_value")
     final boolean booleanValue = true;
-    @Key("float_value")
+    @Key(name = "float_value")
     final float floatValue = -1.0f;
-    @Key("string_set_value")
+    @Key(name = "string_set_value")
     Set<String> stringSetValue;
 }
 

--- a/example/src/main/java/com/example/android/kvs/prefs/schemas/TestWithSerializerPrefsSchema.java
+++ b/example/src/main/java/com/example/android/kvs/prefs/schemas/TestWithSerializerPrefsSchema.java
@@ -1,0 +1,14 @@
+package com.example.android.kvs.prefs.schemas;
+
+import com.example.android.kvs.prefs.serializer.UserIntSerializer;
+import com.example.android.kvs.prefs.serializer.UserStringSerializer;
+import com.rejasupotaro.android.kvs.annotations.Key;
+import com.rejasupotaro.android.kvs.annotations.Table;
+
+@Table(name = "test_with_serializer")
+public class TestWithSerializerPrefsSchema {
+    @Key(name = "user_string", serializer = UserStringSerializer.class)
+    String userString;
+    @Key(name = "user_int", serializer = UserIntSerializer.class)
+    int userInt;
+}

--- a/example/src/main/java/com/example/android/kvs/prefs/serializer/UserIntSerializer.java
+++ b/example/src/main/java/com/example/android/kvs/prefs/serializer/UserIntSerializer.java
@@ -1,0 +1,34 @@
+package com.example.android.kvs.prefs.serializer;
+
+import com.example.android.kvs.models.User;
+import com.rejasupotaro.android.kvs.serializers.Serializer;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class UserIntSerializer implements Serializer<User, Integer> {
+    public static final List<User> USERS = new ArrayList<User>() {{
+        add(new User(1, "Smith", 32, true));
+        add(new User(2, "John", 28, true));
+        add(new User(3, "Robert", 24, false));
+    }};
+
+    @Override
+    public Integer serialize(User src) {
+        int index = -1;
+        for (int i = 0; i < USERS.size(); i++) {
+            if (USERS.get(i).getName().equals(src.getName())) {
+                index = i;
+            }
+        }
+        if (index == -1) {
+            throw new IllegalArgumentException("Given user does not exist.");
+        }
+        return index;
+    }
+
+    @Override
+    public User deserialize(Integer src) {
+        return USERS.get(src);
+    }
+}

--- a/example/src/main/java/com/example/android/kvs/prefs/serializer/UserIntSerializer.java
+++ b/example/src/main/java/com/example/android/kvs/prefs/serializer/UserIntSerializer.java
@@ -1,12 +1,12 @@
 package com.example.android.kvs.prefs.serializer;
 
 import com.example.android.kvs.models.User;
-import com.rejasupotaro.android.kvs.serializers.Serializer;
+import com.rejasupotaro.android.kvs.serializers.PrefsSerializer;
 
 import java.util.ArrayList;
 import java.util.List;
 
-public class UserIntSerializer implements Serializer<User, Integer> {
+public class UserIntSerializer implements PrefsSerializer<User, Integer> {
     public static final List<User> USERS = new ArrayList<User>() {{
         add(new User(1, "Smith", 32, true));
         add(new User(2, "John", 28, true));

--- a/example/src/main/java/com/example/android/kvs/prefs/serializer/UserStringSerializer.java
+++ b/example/src/main/java/com/example/android/kvs/prefs/serializer/UserStringSerializer.java
@@ -2,9 +2,9 @@ package com.example.android.kvs.prefs.serializer;
 
 import com.example.android.kvs.models.User;
 import com.google.gson.Gson;
-import com.rejasupotaro.android.kvs.serializers.Serializer;
+import com.rejasupotaro.android.kvs.serializers.PrefsSerializer;
 
-public class UserStringSerializer implements Serializer<User, String> {
+public class UserStringSerializer implements PrefsSerializer<User, String> {
     @Override
     public String serialize(User src) {
         return new Gson().toJson(src);

--- a/example/src/main/java/com/example/android/kvs/prefs/serializer/UserStringSerializer.java
+++ b/example/src/main/java/com/example/android/kvs/prefs/serializer/UserStringSerializer.java
@@ -1,0 +1,17 @@
+package com.example.android.kvs.prefs.serializer;
+
+import com.example.android.kvs.models.User;
+import com.google.gson.Gson;
+import com.rejasupotaro.android.kvs.serializers.Serializer;
+
+public class UserStringSerializer implements Serializer<User, String> {
+    @Override
+    public String serialize(User src) {
+        return new Gson().toJson(src);
+    }
+
+    @Override
+    public User deserialize(String src) {
+        return new Gson().fromJson(src, User.class);
+    }
+}

--- a/library/src/main/java/com/rejasupotaro/android/kvs/annotations/Key.java
+++ b/library/src/main/java/com/rejasupotaro/android/kvs/annotations/Key.java
@@ -1,5 +1,8 @@
 package com.rejasupotaro.android.kvs.annotations;
 
+import com.rejasupotaro.android.kvs.serializers.DefaultSerializer;
+import com.rejasupotaro.android.kvs.serializers.Serializer;
+
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -8,5 +11,6 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.CLASS)
 @Target(ElementType.FIELD)
 public @interface Key {
-    String value();
+    String name();
+    Class<? extends Serializer> serializer() default DefaultSerializer.class;
 }

--- a/library/src/main/java/com/rejasupotaro/android/kvs/annotations/Key.java
+++ b/library/src/main/java/com/rejasupotaro/android/kvs/annotations/Key.java
@@ -1,7 +1,7 @@
 package com.rejasupotaro.android.kvs.annotations;
 
-import com.rejasupotaro.android.kvs.serializers.DefaultSerializer;
-import com.rejasupotaro.android.kvs.serializers.Serializer;
+import com.rejasupotaro.android.kvs.serializers.DefaultPrefsSerializer;
+import com.rejasupotaro.android.kvs.serializers.PrefsSerializer;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -12,5 +12,5 @@ import java.lang.annotation.Target;
 @Target(ElementType.FIELD)
 public @interface Key {
     String name();
-    Class<? extends Serializer> serializer() default DefaultSerializer.class;
+    Class<? extends PrefsSerializer> serializer() default DefaultPrefsSerializer.class;
 }

--- a/library/src/main/java/com/rejasupotaro/android/kvs/serializers/DefaultPrefsSerializer.java
+++ b/library/src/main/java/com/rejasupotaro/android/kvs/serializers/DefaultPrefsSerializer.java
@@ -1,6 +1,6 @@
 package com.rejasupotaro.android.kvs.serializers;
 
-public class DefaultSerializer implements Serializer<Object, Object> {
+public class DefaultPrefsSerializer implements PrefsSerializer<Object, Object> {
     @Override
     public Object serialize(Object src) {
         return src;

--- a/library/src/main/java/com/rejasupotaro/android/kvs/serializers/DefaultSerializer.java
+++ b/library/src/main/java/com/rejasupotaro/android/kvs/serializers/DefaultSerializer.java
@@ -1,0 +1,13 @@
+package com.rejasupotaro.android.kvs.serializers;
+
+public class DefaultSerializer implements Serializer<Object, Object> {
+    @Override
+    public Object serialize(Object src) {
+        return src;
+    }
+
+    @Override
+    public Object deserialize(Object src) {
+        return src;
+    }
+}

--- a/library/src/main/java/com/rejasupotaro/android/kvs/serializers/PrefsSerializer.java
+++ b/library/src/main/java/com/rejasupotaro/android/kvs/serializers/PrefsSerializer.java
@@ -1,6 +1,6 @@
 package com.rejasupotaro.android.kvs.serializers;
 
-public interface Serializer<A, B> {
+public interface PrefsSerializer<A, B> {
     B serialize(A src);
     A deserialize(B src);
 }

--- a/library/src/main/java/com/rejasupotaro/android/kvs/serializers/Serializer.java
+++ b/library/src/main/java/com/rejasupotaro/android/kvs/serializers/Serializer.java
@@ -1,0 +1,6 @@
+package com.rejasupotaro.android.kvs.serializers;
+
+public interface Serializer<A, B> {
+    B serialize(A src);
+    A deserialize(B src);
+}


### PR DESCRIPTION
I got some feedback about serializer. In this PR, I enabled to specify serializer for keys.

### Usage

Let's say you will store User class to SharedPreferences, 

```java
@Table(name = "example")
public abstract class ExamplePrefsSchema {
    @Key(name = "user", serializer = UserPrefsSerializer.class)
    User user;
}
```

you can specify serializer class through `@Key(serializer = *.class)`. The serializer class would be like below.

```java
public class UserSerializer implements PrefsSerializer<User, String> {
    @Override public String serialize(User src) { return GSON.toJson(src); }
    @Override public User deserialize(String src) { return GSON.fromJson(src, User.class); }
}
```

A method that can be taken User class will be generated.

```java
prefs.putUser(user);
```

Type `A` will be stored as type `B`. So the type of the right value of the key should be `B`.