### PR TITLE
[Bug fix] Deserialize has not been applied when has serializer

### DIFF
--- a/compiler/src/main/java/com/rejasupotaro/android/kvs/internal/SchemaWriter.java
+++ b/compiler/src/main/java/com/rejasupotaro/android/kvs/internal/SchemaWriter.java
@@ -118,9 +118,7 @@ public class SchemaWriter {
                     ? "false"
                     : field.getValue().toString();
             methodSpecs.add(createGetterWithDefaultValue(field, argTypeOfSuperMethod));
-            if (!field.hasSerializer()) {
-                methodSpecs.add(createGetter(field, argTypeOfSuperMethod, defaultValue));
-            }
+            methodSpecs.add(createGetter(field, argTypeOfSuperMethod, defaultValue));
             methodSpecs.addAll(createSetter(field, argTypeOfSuperMethod));
             methodSpecs.add(createHasMethod(field));
             methodSpecs.add(createRemoveMethod(field));
@@ -157,9 +155,7 @@ public class SchemaWriter {
                     ? "0.0F"
                     : field.getValue().toString() + "f";
             methodSpecs.add(createGetterWithDefaultValue(field, argTypeOfSuperMethod));
-            if (!field.hasSerializer()) {
-                methodSpecs.add(createGetter(field, argTypeOfSuperMethod, defaultValue));
-            }
+            methodSpecs.add(createGetter(field, argTypeOfSuperMethod, defaultValue));
             methodSpecs.addAll(createSetter(field, argTypeOfSuperMethod));
             methodSpecs.add(createHasMethod(field));
             methodSpecs.add(createRemoveMethod(field));
@@ -169,9 +165,7 @@ public class SchemaWriter {
                     ? "0"
                     : field.getValue().toString();
             methodSpecs.add(createGetterWithDefaultValue(field, argTypeOfSuperMethod));
-            if (!field.hasSerializer()) {
-                methodSpecs.add(createGetter(field, argTypeOfSuperMethod, defaultValue));
-            }
+            methodSpecs.add(createGetter(field, argTypeOfSuperMethod, defaultValue));
             methodSpecs.addAll(createSetter(field, argTypeOfSuperMethod));
             methodSpecs.add(createHasMethod(field));
             methodSpecs.add(createRemoveMethod(field));
@@ -181,9 +175,7 @@ public class SchemaWriter {
                     ? "0L"
                     : field.getValue().toString() + "L";
             methodSpecs.add(createGetterWithDefaultValue(field, argTypeOfSuperMethod));
-            if (!field.hasSerializer()) {
-                methodSpecs.add(createGetter(field, argTypeOfSuperMethod, defaultValue));
-            }
+            methodSpecs.add(createGetter(field, argTypeOfSuperMethod, defaultValue));
             methodSpecs.addAll(createSetter(field, argTypeOfSuperMethod));
             methodSpecs.add(createHasMethod(field));
             methodSpecs.add(createRemoveMethod(field));


### PR DESCRIPTION
* I found a bug that deserialize has not been applied when has serializer.
* This bug is happening in the long / int / boolean / float types.
* I think there is a problem with the getter method of generating when has serializer.


The class that the following is generated before the modification.

```java
package com.example.android.kvs.prefs.schemas;

import android.content.Context;
import android.content.SharedPreferences;
import com.example.android.kvs.models.User;
import com.example.android.kvs.prefs.serializer.UserIntSerializer;
import com.example.android.kvs.prefs.serializer.UserStringSerializer;
import com.rejasupotaro.android.kvs.PrefsSchema;
import java.lang.String;

public final class TestWithSerializerPrefs extends PrefsSchema {
  public static final String TABLE_NAME = "test_with_serializer";

  private static TestWithSerializerPrefs singleton;

  public TestWithSerializerPrefs(Context context) {
    init(context, TABLE_NAME);
  }

  public TestWithSerializerPrefs(SharedPreferences prefs) {
    init(prefs);
  }

  public static TestWithSerializerPrefs get(Context context) {
    if (singleton != null) return singleton;
    synchronized (TestWithSerializerPrefs.class) { if (singleton == null) singleton = new TestWithSerializerPrefs(context); };
    return singleton;
  }

  public User getUserString() {
    return new UserStringSerializer().deserialize(getString("user_string", ""));
  }

  public void setUserString(User userString) {
    putString("user_string", new UserStringSerializer().serialize(userString));
  }

  public void putUserString(User userString) {
    putString("user_string", new UserStringSerializer().serialize(userString));
  }

  public String getUserString(String defValue) {
    return getString("user_string", defValue);
  }

  public boolean hasUserString() {
    return has("user_string");
  }

  public void removeUserString() {
    remove("user_string");
  }

  public int getUserInt(int defValue) {
    return getInt("user_int", defValue);
  }

  public void setUserInt(User userInt) {
    putInt("user_int", new UserIntSerializer().serialize(userInt));
  }

  public void putUserInt(User userInt) {
    putInt("user_int", new UserIntSerializer().serialize(userInt));
  }

  public boolean hasUserInt() {
    return has("user_int");
  }

  public void removeUserInt() {
    remove("user_int");
  }
}
```

The class that the following is generated after the modification.

```java
package com.example.android.kvs.prefs.schemas;

import android.content.Context;
import android.content.SharedPreferences;
import com.example.android.kvs.models.User;
import com.example.android.kvs.prefs.serializer.UserIntSerializer;
import com.example.android.kvs.prefs.serializer.UserStringSerializer;
import com.rejasupotaro.android.kvs.PrefsSchema;
import java.lang.String;

public final class TestWithSerializerPrefs extends PrefsSchema {
  public static final String TABLE_NAME = "test_with_serializer";

  private static TestWithSerializerPrefs singleton;

  public TestWithSerializerPrefs(Context context) {
    init(context, TABLE_NAME);
  }

  public TestWithSerializerPrefs(SharedPreferences prefs) {
    init(prefs);
  }

  public static TestWithSerializerPrefs get(Context context) {
    if (singleton != null) return singleton;
    synchronized (TestWithSerializerPrefs.class) { if (singleton == null) singleton = new TestWithSerializerPrefs(context); };
    return singleton;
  }

  public User getUserString() {
    return new UserStringSerializer().deserialize(getString("user_string", ""));
  }

  public void setUserString(User userString) {
    putString("user_string", new UserStringSerializer().serialize(userString));
  }

  public void putUserString(User userString) {
    putString("user_string", new UserStringSerializer().serialize(userString));
  }

  public String getUserString(String defValue) {
    return getString("user_string", defValue);
  }

  public boolean hasUserString() {
    return has("user_string");
  }

  public void removeUserString() {
    remove("user_string");
  }

  public int getUserInt(int defValue) {
    return getInt("user_int", defValue);
  }

  public User getUserInt() {
    return new UserIntSerializer().deserialize(getInt("user_int", 0));
  }

  public void setUserInt(User userInt) {
    putInt("user_int", new UserIntSerializer().serialize(userInt));
  }

  public void putUserInt(User userInt) {
    putInt("user_int", new UserIntSerializer().serialize(userInt));
  }

  public boolean hasUserInt() {
    return has("user_int");
  }

  public void removeUserInt() {
    remove("user_int");
  }
}
```
